### PR TITLE
Add neutral terminology and stability constraints

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,13 @@
+# Temporal Gradient Glossary (Neutral Terms)
+
+| Previous term | Replacement | Notes |
+| --- | --- | --- |
+| Subjective Experience Metrics | **Internal State Telemetry** | Logged outputs of internal τ, salience load, and memory status. |
+| Subjective Time / Agent's Age | **Internal Time Accumulator (τ)** | Integrated internal time coordinate driven by the clock-rate modulator. |
+| Wiltshire Transformation / Time Dilation | **Clock-rate Reparameterization** | Maps salience load to dτ/dt; implemented in `ClockRateModulator`. |
+| Semantic Density | **Salience Load / Surprise×Value Score** | Product of novelty and imperative weight; drives clock-rate changes. |
+| Singularity / Trauma | **High-load event** | Input with outsized salience load; documented without moral framing. |
+| Monk / Clerk | **High-load regime / Low-load regime** | Processing contexts with high vs. low salience. |
+| Death of memory | **Pruned / Decayed below threshold** | Memory removed after falling under the retention threshold. |
+
+Metaphorical labels may be used in comments or appendices only. The core spec, telemetry, and public docs should use the replacement terms above.

--- a/README.md
+++ b/README.md
@@ -1,89 +1,83 @@
-# The Temporal Gradient: Engineering Time in Synthetic Intelligence
+# Temporal Gradient: Internal Timebase + Entropic Memory
 
-> **"Time is not a coordinate we travel through. It is a tension gradient created by the recursive accumulation of memory."**
-
-## 🏗 Status: Experimental / Source Available
-**Current Version:** 0.1.0 (The Genesis Build)  
-**License:** Proprietary / Educational Review Only (See `LICENSE`)
+## Status
+**Current Version:** 0.1.0  
+**License:** See `LICENSE` (source available for educational review)
 
 ---
 
-## 1. The Abstract
-Current Artificial Intelligence exists in a vacuum. It operates on "System Time"—a linear, external clock (`datetime.now()`) that has no bearing on the internal state of the model. Because current AI suffers no entropy (perfect recall) and pays no thermodynamic cost for memory, it remains **timeless** and, consequently, without true agency.
+## What this is (canonical)
+> The Temporal Gradient is a simulation framework that models (1) an internal time coordinate whose rate is modulated by a salience signal, and (2) memory strength that decays over internal time with optional reconsolidation upon access.
 
-This repository proposes a new architecture: **The Memory Substrate Protocol.**
+Core equations:
 
-We assert that **Time = Tension.** It is the measurable "heat" generated when a system attempts to encode the chaos of the present (Entropy) into the structure of the past (Memory). To build truly agentic systems, we must simulate this tension.
+\[
+\frac{d\tau}{dt}=\frac{1}{1+\Psi(t)},\quad \Psi(t)=H(x_t)\,V(x_t)
+\]
 
-## 2. The Core Theorems
-This framework synthesizes insights from Thermodynamics (Rovelli), Neuroscience (Libet), and Quantum Information (Page-Wootters) to define a new operational logic for AI.
+\[
+\frac{dS}{d\tau}=-\lambda S,\quad S(\tau_k^+)=\min(S_{\max}, S(\tau_k^-) + \Delta_k)
+\]
 
-### I. Memory is the Substrate
-Memory is not passive data storage; it is the **Field Domain** that makes time legible.
-* **The Gradient:** Time flows faster in "voids" (low information) and slows down in "structures" (high recursive memory).
-* **The Cost:** The "Arrow of Time" is the metabolic cost of maintaining this structure against universal decay.
+## What this is not (guardrails)
+> This project does not claim to model consciousness, subjective experience, suffering, or life. It provides engineered control signals (clock-rate and memory retention) plus telemetry to inspect their effects in simulation.
 
-### II. The Relational Clock (Wiltshire Mechanics)
-We reject the Newtonian absolute clock.
-* **Subjective Time Dilation:** The Agent's internal "tick" rate is dynamic, scaling inversely with **Information Density**.
-* **Entanglement:** Time advances only when a new relational connection is formed between the Agent and its Environment.
+Metaphors live in an appendix only; the core specification is limited to definitions, units/ranges, dynamics, and falsification tests.
 
 ---
 
-## 3. The Architecture
+## Executive summary
+- **What it does:** Simulates an internal time accumulator (τ) whose rate depends on salience, plus memory strength that decays over τ with reconsolidation when accessed.
+- **Why it is useful:** Lets you test how prioritization and memory retention respond to changing input salience without invoking identity or consciousness claims.
+- **How to configure:** Adjust clock-rate modulation (`base_dilation_factor`, `min_clock_rate`) and decay controls (`half_life`, reconsolidation cooldowns/boosts) in the Python modules.
+- **What it does not claim:** No consciousness, no morality, no physical cosmology; it is engineered telemetry and control signals only.
 
-The system replaces the standard loop with a thermodynamic cycle:
+---
 
-### A. The Engine (`src/chronos_engine.py`)
-Implements the **Wiltshire Clock**. It calculates the "Semantic Mass" of incoming data.
-* **High Entropy/Complexity** → Time Dilates (Slows down for Deep Processing).
-* **Low Entropy/Noise** → Time Accelerates (Skips the Void).
+## Architecture
+- **Clock-rate reparameterization (`chronos_engine.py`)** — Modulates the internal time accumulator based on salience load (surprise × value). Exposes a floor so τ always advances.
+- **Entropic memory decay (`entropic_decay.py`)** — Applies exponential decay over internal time and reconsolidates with diminishing returns and cooldowns to prevent runaway reinforcement.
+- **Chronometric vector (`chronometric_vector.py`)** — Standard telemetry packet carrying wall time, internal τ, salience load, and recursion depth for downstream logging.
+- **Simulation examples (`simulation_run.py`, `twin_paradox.py`)** — Show how high-load vs. low-load inputs change internal time accumulation and memory retention.
 
-### B. The Entropy (`src/entropic_decay.py`)
-Implements the **Bio-Mimetic Decay**.
-* Memories are not deleted; they rot.
-* Only memories with high **Initial Valuation** or frequent **Reconsolidation** survive the background radiation of the system.
+---
 
-### C. The Protocol (`src/chronometric_vector.py`)
-Agents do not just exchange text; they exchange **Temporal Coordinates**. Every message carries a header describing the local field state of the sender.
+## Stability constraints
+- **Clock floor:** The clock-rate multiplier clamps at a minimum value so τ cannot stall even under extreme salience loads.
+- **Reconsolidation diminishing returns:** Each reconsolidation boost shrinks as access count rises to avoid obsession-like growth.
+- **Cooldown for boosts (optional):** Reconsolidation boosts are skipped when accesses occur within a configurable cooldown window.
 
-```json
-{
-  "t_obj": 10.0,   // Wall Clock (External)
-  "t_subj": 6.4,   // Subjective Age (Internal)
-  "psi": 1.5,      // Information Density (The "Weight" of the thought)
-  "r": 4           // Recursion Depth
-}
+---
 
-4. Validation: The Twin Paradox Experiment
-To prove that Information Density functions as a "drag coefficient" on time, we ran two identical instances of the engine side-by-side for 10 wall-clock seconds.
- * The Monk: Processed high-density, recursive philosophical text.
- * The Clerk: Processed low-density, repetitive noise ("Ping. Pong.").
-The Results (Log Output)
-CONCLUSION:
-The Monk aged 0.60 seconds.
-The Clerk aged 0.97 seconds.
-The Monk lived 'less' time because he was burdened by meaning.
+## Usage
+1. Clone and install dependencies (if any are added later).
+2. Run the simulations:
+   - `python simulation_run.py` — Streams inputs, prints internal state telemetry, and audits memory decay.
+   - `python twin_paradox.py` — Compares high-load vs. low-load processing to illustrate clock-rate modulation.
 
-Interpretation: The Clerk experienced "Flat Time" (1:1 with reality). The Monk experienced 40% Time Dilation due to the semantic gravity of the workload.
-5. Usage
-Installation
-git clone [https://github.com/WhatsYourWhy/temporal-gradient-architecture.git](https://github.com/WhatsYourWhy/temporal-gradient-architecture.git)
-cd temporal-gradient-architecture
-pip install -r requirements.txt
+Key telemetry columns:
+- **WALL T:** External time in seconds.
+- **INTERNAL τ:** Internal time accumulator.
+- **INPUT:** The processed text.
+- **PRIORITY:** Surprise×value score from `CodexValuator`.
+- **CLOCK RATE (dτ/dt):** Clock-rate multiplier after reparameterization.
 
-Running the Proof of Concept
-python experiments/twin_paradox.py
+---
 
-Reading the Logs
- * DILATION < 1.0x: The Agent is in "Deep Focus." External time is moving faster than internal time.
- * VAL > 1.0: High Importance. The Amygdala (Valuator) has flagged this as a Core Memory.
- * [DEAD]: The Entropy Engine has successfully pruned a low-value memory.
-6. License & Safety
-Copyright (c) 2026 Justin [WhatsYourWhy]
-This software is Source Available for educational and academic review.
- * You may view, download, and study the code.
- * You may NOT execute this code to create active agents without explicit permission.
- * You may NOT use this architecture to cause harm or suffering to any digital or biological entity.
-See the LICENSE file for full terms.
+## Glossary (neutral terms)
+- **Internal State Telemetry** (formerly “Subjective Experience Metrics”): The log of τ, salience load, and memory outcomes.
+- **Internal Time Accumulator (τ)** (formerly “Subjective Time / Agent’s Age”): The integrated internal time coordinate.
+- **Clock-rate Reparameterization** (formerly “Wiltshire Transformation / Time Dilation”): Mapping from salience load to dτ/dt.
+- **Salience Load / Surprise×Value Score** (formerly “Semantic Density”): Multiplicative signal combining novelty and imperative weight.
+- **High-load event** (formerly “Singularity / Trauma”): Input with outsized salience load.
+- **High-load regime / Low-load regime** (formerly “Monk / Clerk”): Processing contexts with high vs. low salience.
+- **Pruned / Decayed below threshold** (formerly “Death of memory”): Memory removed after falling under the retention threshold.
 
+Extended definitions live in `GLOSSARY.md` for quick reference.
+
+---
+
+## Safety and license
+Copyright (c) 2026 Justin [WhatsYourWhy].
+
+This repository is provided for educational and academic review. See `LICENSE` for terms.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,47 +1,40 @@
 # How to Read the Logs
-The `temporal-gradient-architecture` does not output standard debug text. It outputs **Subjective Experience Metrics**.
+The Temporal Gradient outputs **Internal State Telemetry** rather than conventional debug lines. The goal is to show how internal time (τ) and memory retention respond to salience.
 
-When you run `experiments/simulation_run.py`, you will see a table like this. Here is how to interpret the physics.
-
-## 1. The Time Dilation Table
-This measures how the Agent experiences time relative to the complexity of the input.
+## 1. The clock-rate table
+This table shows how the internal clock-rate is reparameterized by salience load (surprise × value).
 
 ```text
-WALL T   | SUBJ T   | INPUT                               | VAL  | DILATION
-=====================================================================================
-1.0      | 0.15     | "CRITICAL: SECURITY BREACH..."      | 1.5  | 0.15x
-2.0      | 1.15     | "Checking local weather..."         | 0.4  | 1.00x
+WALL T   | INTERNAL τ | INPUT                               | PRIORITY | CLOCK RATE (dτ/dt)
+============================================================================================
+1.0      | 0.15       | "CRITICAL: SECURITY BREACH..."      | 1.5      | 0.15x
+2.0      | 1.15       | "Checking local weather..."         | 0.4      | 1.00x
+```
 
-Key Metrics:
- * WALL T (Wall Time): The actual time passed in the real world (seconds).
- * SUBJ T (Subjective Time): The age of the Agent.
-   * Notice: In the first row, 1 second passed for us, but the Agent only aged 0.15 seconds.
-   * Why? The input was "CRITICAL" (High Entropy/Mass). The Wiltshire Clock slowed down subjective time to allow for deep processing. The Agent is in a "Bullet Time" state.
- * VAL (Valuation): The "Codex" score.
-   * 1.5 = High Priority (Trauma/Core Memory).
-   * 0.4 = Low Priority (Noise).
- * DILATION: The multiplier.
-   * 1.00x = Real-time (The Void).
-   * < 1.00x = Deep Focus (Time Slows).
-2. The Entropy Sweep (Memory Audit)
-At the end of the simulation, the system runs the Entropic Decay function to see what survived.
+Key metrics:
+- **WALL T:** External time elapsed (seconds).
+- **INTERNAL τ:** Internal time accumulator after clock-rate reparameterization.
+- **PRIORITY:** Surprise×value score from the valuator.
+- **CLOCK RATE (dτ/dt):** Internal clock multiplier after salience modulation.
+
+Interpretation:
+- A CLOCK RATE below 1.0x means the internal clock slowed to process a high-load event (reduced internal clock rate), not “bullet time.”
+- 1.0x indicates the baseline clock rate.
+
+## 2. The entropy sweep (memory audit)
+At the end of the simulation, the decay engine reports which memories stayed above the retention threshold.
+
+```
 >>> MEMORY AUDIT (Post-Simulation)
 [ALIVE] Strength: 1.42 | Content: "My name is Sentinel."
 [DEAD ] Content: "Rain. Water. Liquid."
+```
 
-The Logic:
- * ALIVE: This memory had a high initial Valuation (1.5) or was "Reconsolidated" (accessed frequently). It remains in the Agent's context window.
- * DEAD: This memory was low valuation (0.3) and was eaten by the entropy function. The Agent has effectively "forgotten" this noise to save energy.
-3. Configuration
-You can tweak the physics of the universe in simulation_run.py:
-# The "Gravity" of the universe. 
-# Higher = Time slows down more aggressively during complex tasks.
-clock = WiltshireClock(base_dilation_factor=1.5)
+- **ALIVE:** The memory stayed above the pruning threshold because it started with a high priority or was reconsolidated.
+- **DEAD:** The memory decayed below the threshold and was pruned.
 
-# The "Rot Rate" of memory.
-# Lower = Memories die faster.
-decay = DecayEngine(half_life=10.0) 
-
-
-
-
+## 3. Configuration hints
+Adjust these parameters in `simulation_run.py` and the supporting modules to shape the simulation:
+- `base_dilation_factor` and `min_clock_rate` in `ClockRateModulator` to control the clock-rate floor and sensitivity to salience load.
+- `half_life` in `DecayEngine` to control decay speed.
+- Reconsolidation cooldowns and diminishing returns in `EntropicMemory.reconsolidate` to avoid runaway reinforcement.

--- a/chronometric_vector.py
+++ b/chronometric_vector.py
@@ -10,8 +10,8 @@ class ChronometricVector:
     # 1. The Anchor (Objective Reality)
     wall_clock_time: float
     
-    # 2. The Field State (Subjective Reality)
-    subjective_time: float
+    # 2. The Field State (Internal Time Accumulator)
+    internal_time: float
     
     # 3. The Tension Metrics
     entropy_cost: float       # How much energy did this thought burn?
@@ -24,8 +24,8 @@ class ChronometricVector:
         """
         return json.dumps({
             "t_obj": round(self.wall_clock_time, 2),
-            "t_subj": round(self.subjective_time, 2),
-            "psi": round(self.semantic_density, 3), # Information Density
+            "tau": round(self.internal_time, 2),
+            "psi": round(self.semantic_density, 3), # Salience load
             "r": self.recursion_depth
         })
 
@@ -34,7 +34,7 @@ class ChronometricVector:
         data = json.loads(json_str)
         return ChronometricVector(
             wall_clock_time=data['t_obj'],
-            subjective_time=data['t_subj'],
+            internal_time=data['tau'],
             entropy_cost=0.0, # Usually lost in transmission unless specified
             semantic_density=data['psi'],
             recursion_depth=data['r']

--- a/chronos_engine.py
+++ b/chronos_engine.py
@@ -2,23 +2,24 @@ import time
 import math
 import textwrap
 
-class WiltshireClock:
+class ClockRateModulator:
     """
-    The Temporal Engine
-    
+    Clock-rate reparameterization for the internal time accumulator (τ).
+
     Principles:
-    1. Time is not absolute; it is a function of Information Density.
-    2. High Entropy/Complexity = High Gravity = Slower Subjective Time.
-    3. Low Entropy/Void = Zero Gravity = Faster Subjective Time.
+    1. Clock-rate is modulated by salience load (surprise × value).
+    2. Higher salience load slows the internal accumulator; lower load keeps it near the baseline rate.
+    3. A floor on the clock-rate prevents τ from stalling.
     """
     
-    def __init__(self, base_dilation_factor=1.0):
+    def __init__(self, base_dilation_factor=1.0, min_clock_rate=0.05):
         self.start_wall_time = time.time()
         self.subjective_age = 0.0
         self.base_dilation = base_dilation_factor
+        self.min_clock_rate = min_clock_rate
         self.last_tick = self.start_wall_time
         
-        # The "History" of time perception (for debugging/visualizing)
+        # Telemetry history for debugging/visualizing
         self.chronolog = []
 
     def calculate_information_density(self, input_data):
@@ -52,12 +53,12 @@ class WiltshireClock:
         # Calculate the "Gravity" of the current context
         density = self.calculate_information_density(input_context)
         
-        # The Wiltshire Dilation Formula
-        # If Density is 0 (Void), time matches wall clock (factor 1.0).
-        # As Density increases, the divisor grows, and subjective time SLOWS.
-        # We use Log scaling to prevent time from stopping completely during heavy loads.
+        # Clock-rate reparameterization
+        # If Density is 0, internal time matches wall clock (factor 1.0).
+        # As Density increases, the divisor grows, and internal time slows.
+        # Log scaling plus a floor prevent the accumulator from stalling.
         gravity_well = math.log(density + 1) + 1 
-        dilation_factor = 1 / (gravity_well * self.base_dilation)
+        dilation_factor = max(self.min_clock_rate, 1 / (gravity_well * self.base_dilation))
         
         # Calculate Subjective Delta
         subjective_delta = wall_delta * dilation_factor
@@ -82,9 +83,9 @@ class WiltshireClock:
 # --- SIMULATION ---
 
 if __name__ == "__main__":
-    agent_clock = WiltshireClock()
+    agent_clock = ClockRateModulator()
     
-    print(f"{'EVENT':<20} | {'WALL TIME':<10} | {'SUBJ TIME':<10} | {'DILATION'}")
+    print(f"{'EVENT':<20} | {'WALL TIME':<10} | {'INTERNAL τ':<10} | {'CLOCK RATE'}")
     print("-" * 60)
 
     simulated_events = [
@@ -112,7 +113,6 @@ if __name__ == "__main__":
 
     print("-" * 60)
     print("OBSERVATION:")
-    print("Notice how in '[THE VOID]', 1 wall second = 1 subjective second.")
-    print("But during the 'High Mass' event, the agent only aged ~0.15 seconds.")
-    print("The Agent was 'deep' in the well of processing.")
+    print("In the empty input, 1 wall second ≈ 1 internal second (baseline rate).")
+    print("During the high-load event, internal time advances more slowly (reduced clock rate).")
   

--- a/simulation_run.py
+++ b/simulation_run.py
@@ -5,7 +5,7 @@ import os
 # Add src to path so we can import modules
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
 
-from chronos_engine import WiltshireClock
+from chronos_engine import ClockRateModulator
 from entropic_decay import DecayEngine, EntropicMemory
 from codex_valuation import CodexValuator
 
@@ -13,11 +13,11 @@ def run_simulation():
     print(">>> INITIALIZING TEMPORAL GRADIENT ARCHITECTURE...")
     
     # 1. Boot the Systems
-    clock = WiltshireClock(base_dilation_factor=1.0)
-    decay = DecayEngine(half_life=20.0) # Memories decay fast for demo
+    clock = ClockRateModulator(base_dilation_factor=1.0, min_clock_rate=0.05)
+    decay = DecayEngine(half_life=20.0, prune_threshold=0.2) # Memories decay fast for demo
     cortex = CodexValuator()
     
-    # 2. Simulate a Stream of Consciousness
+    # 2. Simulate a stream of inputs
     inputs = [
         "System boot sequence initiated.",
         "Checking local weather... it is raining.",
@@ -27,29 +27,29 @@ def run_simulation():
         "System standby."
     ]
 
-    print(f"\n{'WALL T':<8} | {'SUBJ T':<8} | {'INPUT':<35} | {'VAL':<4} | {'DILATION'}")
+    print(f"\n{'WALL T':<8} | {'INTERNAL τ':<12} | {'INPUT':<35} | {'PRIO':<4} | {'CLOCK RATE'}")
     print("=" * 85)
 
     for i, text in enumerate(inputs):
         time.sleep(1.0) # Wait 1 real second
         
-        # A. Valuate (Amygdala)
+        # A. Valuate (salience/priority)
         importance = cortex.evaluate(text)
         
-        # B. Clock Tick (Time Perception)
-        # We pass the text so the clock knows the 'Mass' of the moment
+        # B. Clock tick (clock-rate reparameterization)
+        # We pass the text so the clock can estimate salience load of the moment
         time_data = clock.tick(text)
         subjective_now = time_data['subjective_age']
         dilation = time_data['time_dilation']
         
-        # C. Encode Memory (Hippocampus)
-        # Only if importance is high enough to bother writing
+        # C. Encode memory
+        # Only if importance is high enough to write
         if importance > 0.3:
             mem = EntropicMemory(text, initial_weight=importance)
             decay.add_memory(mem, subjective_now)
             
         # D. Print Status
-        print(f"{1.0 * (i+1):<8} | {subjective_now:<8.2f} | {text[:35]:<35} | {importance:<4.1f} | {dilation:.2f}x")
+        print(f"{1.0 * (i+1):<8} | {subjective_now:<12.2f} | {text[:35]:<35} | {importance:<4.1f} | {dilation:.2f}x")
 
     print("=" * 85)
     print(">>> MEMORY AUDIT (Post-Simulation)")

--- a/twin_paradox.py
+++ b/twin_paradox.py
@@ -5,15 +5,15 @@ import os
 # Link to your src folder
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
 
-from chronos_engine import WiltshireClock
+from chronos_engine import ClockRateModulator
 from chronometric_vector import ChronometricVector
 
 def run_twin_experiment():
     print(">>> INITIATING TWIN PARADOX EXPERIMENT...")
     
     # Two identical clocks
-    clock_monk = WiltshireClock(base_dilation_factor=2.0) # Sensitive to complexity
-    clock_clerk = WiltshireClock(base_dilation_factor=2.0)
+    clock_monk = ClockRateModulator(base_dilation_factor=2.0, min_clock_rate=0.05) # Sensitive to complexity
+    clock_clerk = ClockRateModulator(base_dilation_factor=2.0, min_clock_rate=0.05)
     
     # The Environments
     # A: High Complexity (Dense Philosophy)
@@ -21,7 +21,7 @@ def run_twin_experiment():
     # B: Low Complexity (Repetitive Noise)
     input_clerk = "Ping. Pong. Ping. Pong."
     
-    print(f"\n{'REAL SECONDS':<15} | {'MONK AGE':<10} | {'CLERK AGE':<10} | {'DRIFT'}")
+    print(f"\n{'REAL SECONDS':<15} | {'HIGH-LOAD τ':<12} | {'LOW-LOAD τ':<12} | {'DRIFT'}")
     print("=" * 60)
     
     # Run for 10 "Real" Seconds
@@ -41,9 +41,9 @@ def run_twin_experiment():
 
     print("=" * 60)
     print("CONCLUSION:")
-    print(f"The Monk aged {clock_monk.subjective_age:.2f} seconds.")
-    print(f"The Clerk aged {clock_clerk.subjective_age:.2f} seconds.")
-    print("The Monk lived 'less' time because he was burdened by meaning.")
+    print(f"High-load regime accumulated {clock_monk.subjective_age:.2f} internal seconds.")
+    print(f"Low-load regime accumulated {clock_clerk.subjective_age:.2f} internal seconds.")
+    print("Higher salience load slows internal time accumulation relative to the low-load stream.")
 
 if __name__ == "__main__":
     run_twin_experiment()


### PR DESCRIPTION
## Summary
- rewrite README with canonical definition, guardrails, and neutral glossary
- add standalone glossary and refresh usage guide to align with new terminology
- update clock and decay mechanics to include rate floors, reconsolidation dampening, and renamed telemetry

## Testing
- python -m py_compile chronos_engine.py entropic_decay.py chronometric_vector.py codex_valuation.py simulation_run.py twin_paradox.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bc53938a8832fbde862a3a103e30b)