### PR TITLE
Split CodexValuator into novelty/value scorers and add SaliencePipeline adapters

### DIFF
--- a/salience_pipeline.py
+++ b/salience_pipeline.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List, Protocol, Tuple
+from typing import Dict, Iterable, List, Protocol, Tuple, TYPE_CHECKING
 import re
+
+if TYPE_CHECKING:
+    from codex_valuation import CodexValuator
 
 
 class NoveltyScorer(Protocol):
@@ -112,3 +115,19 @@ class SaliencePipeline:
         diagnostics.update(novelty_diag)
         diagnostics.update(value_diag)
         return SalienceComponents(novelty=novelty, value=value, psi=psi, diagnostics=diagnostics)
+
+
+class CodexNoveltyAdapter:
+    def __init__(self, codex: "CodexValuator") -> None:
+        self.codex = codex
+
+    def score(self, text: str) -> Tuple[float, Dict[str, float]]:
+        return self.codex.score_H(text)
+
+
+class CodexValueAdapter:
+    def __init__(self, codex: "CodexValuator") -> None:
+        self.codex = codex
+
+    def score(self, text: str) -> Tuple[float, Dict[str, float]]:
+        return self.codex.score_V(text)

--- a/simulation_run.py
+++ b/simulation_run.py
@@ -8,6 +8,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 's
 from chronos_engine import ClockRateModulator
 from entropic_decay import DecayEngine, EntropicMemory
 from codex_valuation import CodexValuator
+from salience_pipeline import CodexNoveltyAdapter, CodexValueAdapter, SaliencePipeline
 
 def run_simulation():
     print(">>> INITIALIZING TEMPORAL GRADIENT ARCHITECTURE...")
@@ -16,6 +17,7 @@ def run_simulation():
     clock = ClockRateModulator(base_dilation_factor=1.0, min_clock_rate=0.05)
     decay = DecayEngine(half_life=20.0, prune_threshold=0.2) # Memories decay fast for demo
     cortex = CodexValuator()
+    salience = SaliencePipeline(CodexNoveltyAdapter(cortex), CodexValueAdapter(cortex))
     
     # 2. Simulate a stream of inputs
     inputs = [
@@ -34,7 +36,8 @@ def run_simulation():
         time.sleep(1.0) # Wait 1 real second
         
         # A. Valuate (salience/priority)
-        importance = cortex.evaluate(text)
+        components = salience.evaluate(text)
+        importance = components.psi
         
         # B. Clock tick (clock-rate reparameterization)
         # We pass the text so the clock can estimate salience load of the moment


### PR DESCRIPTION
### Motivation
- Separate novelty (H) and value (V) scoring so the valuation logic can be consumed by the salience pipeline as distinct signals.
- Provide lightweight adapters to allow the existing `CodexValuator` to satisfy the `NoveltyScorer` and `ValueScorer` protocols without rewriting the pipeline.
- Replace downstream single "tension" usage with the pipeline's structured `SaliencePipeline.evaluate()` output so callers can use `psi` and diagnostics.

### Description
- In `codex_valuation.py` `calculate_novelty` now returns `(novelty, max_similarity)`, and the class exposes `score_H(text)` and `score_V(text)` while `evaluate(text)` composes them and returns the clamped final score.
- `score_H` and `score_V` now return `(value, diagnostics)` dictionaries with keys like `H_max_similarity`, `H_history`, `V_imperative_hit`, `V_identity_hit`, and `V_length_penalty`, and the value heuristics were slightly refactored and typed with `Tuple`/`Dict` hints.
- In `salience_pipeline.py` added `CodexNoveltyAdapter` and `CodexValueAdapter` that call `CodexValuator.score_H` and `score_V` respectively to satisfy the `NoveltyScorer`/`ValueScorer` protocols, and kept `SaliencePipeline.evaluate()` producing a `SalienceComponents` object (including `psi`).
- Updated `simulation_run.py` and the `__main__` demo in `codex_valuation.py` to use `SaliencePipeline.evaluate()` and to use `components.psi` for priority/encoding decisions.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a41d92f14832fb891a0345a664e1f)