### PR TITLE
Use psi-driven salience pipeline in simulation run

### DIFF
--- a/simulation_run.py
+++ b/simulation_run.py
@@ -7,8 +7,11 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 's
 
 from chronos_engine import ClockRateModulator
 from entropic_decay import DecayEngine, EntropicMemory
-from codex_valuation import CodexValuator
-from salience_pipeline import CodexNoveltyAdapter, CodexValueAdapter, SaliencePipeline
+from salience_pipeline import (
+    KeywordImperativeValue,
+    RollingJaccardNovelty,
+    SaliencePipeline,
+)
 
 def run_simulation():
     print(">>> INITIALIZING TEMPORAL GRADIENT ARCHITECTURE...")
@@ -16,8 +19,7 @@ def run_simulation():
     # 1. Boot the Systems
     clock = ClockRateModulator(base_dilation_factor=1.0, min_clock_rate=0.05)
     decay = DecayEngine(half_life=20.0, prune_threshold=0.2) # Memories decay fast for demo
-    cortex = CodexValuator()
-    salience = SaliencePipeline(CodexNoveltyAdapter(cortex), CodexValueAdapter(cortex))
+    salience = SaliencePipeline(RollingJaccardNovelty(), KeywordImperativeValue())
     
     # 2. Simulate a stream of inputs
     inputs = [
@@ -36,23 +38,22 @@ def run_simulation():
         time.sleep(1.0) # Wait 1 real second
         
         # A. Valuate (salience/priority)
-        components = salience.evaluate(text)
-        importance = components.psi
+        sal = salience.evaluate(text)
         
         # B. Clock tick (clock-rate reparameterization)
         # We pass the text so the clock can estimate salience load of the moment
-        time_data = clock.tick(text)
-        subjective_now = time_data['subjective_age']
-        dilation = time_data['time_dilation']
+        clock.tick(sal.psi, input_context=text)
+        subjective_now = clock.subjective_age
+        dilation = clock.clock_rate_from_psi(sal.psi)
         
         # C. Encode memory
         # Only if importance is high enough to write
-        if importance > 0.3:
-            mem = EntropicMemory(text, initial_weight=importance)
+        if sal.psi > 0.3:
+            mem = EntropicMemory(text, initial_weight=sal.psi)
             decay.add_memory(mem, subjective_now)
             
         # D. Print Status
-        print(f"{1.0 * (i+1):<8} | {subjective_now:<12.2f} | {text[:35]:<35} | {importance:<4.1f} | {dilation:.2f}x")
+        print(f"{1.0 * (i+1):<8} | {subjective_now:<12.2f} | {text[:35]:<35} | {sal.psi:<4.1f} | {dilation:.2f}x")
 
     print("=" * 85)
     print(">>> MEMORY AUDIT (Post-Simulation)")


### PR DESCRIPTION
### Motivation
- Switch the simulation to use the built-in lightweight salience scorers and drive time/memory logic from the computed salience (`psi`) rather than the previous Codex adapters.

### Description
- Replace `CodexValuator` adapters with `RollingJaccardNovelty` and `KeywordImperativeValue` and instantiate `SaliencePipeline` with them; call `salience.evaluate(text)` each step to get `sal.psi` and update imports accordingly.
- Pass `sal.psi` into the clock via `clock.tick(sal.psi, input_context=text)` and derive `dilation` from `clock.clock_rate_from_psi(sal.psi)`.
- Use `sal.psi` as the encode threshold and as the `initial_weight` when creating `EntropicMemory` (i.e. `EntropicMemory(text, initial_weight=sal.psi)`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a42ab3280832f9e11a4de1acfa4f0)