### PR TITLE
Add ChronometricVector telemetry fields and emit packets in demos

### DIFF
--- a/simulation_run.py
+++ b/simulation_run.py
@@ -6,6 +6,7 @@ import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
 
 from chronos_engine import ClockRateModulator
+from chronometric_vector import ChronometricVector
 from entropic_decay import (
     DecayEngine,
     EntropicMemory,
@@ -39,6 +40,8 @@ def run_simulation():
     print(f"\n{'WALL T':<8} | {'INTERNAL τ':<12} | {'INPUT':<35} | {'PRIO':<4} | {'CLOCK RATE'}")
     print("=" * 85)
 
+    start_time = time.time()
+
     for i, text in enumerate(inputs):
         time.sleep(1.0) # Wait 1 real second
         
@@ -58,13 +61,27 @@ def run_simulation():
             mem = EntropicMemory(text, initial_weight=strength)
             decay.add_memory(mem, subjective_now)
             
-        # D. Print Status
+        # D. Emit Chronometric Packet
+        wall_time = time.time() - start_time
+        vector = ChronometricVector(
+            wall_clock_time=wall_time,
+            tau=subjective_now,
+            psi=sal.psi,
+            recursion_depth=0,
+            clock_rate=dilation,
+            H=sal.novelty,
+            V=sal.value,
+        )
+        packet = vector.to_packet()
+
+        # E. Print Status
         print(f"{1.0 * (i+1):<8} | {subjective_now:<12.2f} | {text[:35]:<35} | {sal.psi:<4.1f} | {dilation:.2f}x")
+        print(f"{'PACKET':<8} | {packet}")
 
     print("=" * 85)
     print(">>> MEMORY AUDIT (Post-Simulation)")
     
-    # E. Check what survived
+    # F. Check what survived
     current_subj_time = clock.subjective_age
     survivors, dead = decay.entropy_sweep(current_subj_time)
     


### PR DESCRIPTION
### Motivation
- Provide richer, stable telemetry for temporal-gradient messages by encoding internal time (`tau`), salience (`psi`), and optional telemetry such as `clock_rate`, `H`, and `V` while preserving packet keys (`t_obj`, `tau`, `psi`, `r`).
- Ensure downstream tools can parse both new and legacy packets by supporting `semantic_density -> psi` fallback in packet parsing.
- Emit standardized `ChronometricVector` packets from the simulation and twin-paradox demos so telemetry is consistently produced for logging/analysis.

### Description
- Updated `chronometric_vector.py` to rename the internal time field to `tau`, expose `psi` and `recursion_depth`, and add optional fields `clock_rate`, `H`, `V`, and `entropy_cost`, while keeping serialized packet keys stable and adding `from_packet()` fallback from `semantic_density` to `psi`.
- Extended `to_packet()` to include optional `clock_rate`, `H`, and `V` only when provided and to continue emitting `t_obj`, `tau`, `psi`, and `r` keys.
- Modified `simulation_run.py` to construct a `ChronometricVector` per input step (including `wall_clock_time`, `tau`, `psi`, `clock_rate`, `H`, `V`) and print the serialized packet alongside existing status output.
- Modified `twin_paradox.py` to tick clocks using computed `psi`, compute `clock_rate` values, emit `ChronometricVector` packets for both agents with `wall_clock_time`, `tau`, `psi`, and `clock_rate`, and print those packets.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4400cca8832fb3607e084f79a09c)