### PR TITLE
Align demo terminology to high/low salience and replace sensitive example strings

### DIFF
--- a/chronos_engine.py
+++ b/chronos_engine.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":
         # The Agent "Experiences" the event
         d_tau = agent_clock.tick(psi, input_context=event)
         
-        label = (event[:15] + '...') if len(event) > 15 else (event if event else "[THE VOID]")
+        label = (event[:15] + '...') if len(event) > 15 else (event if event else "[EMPTY INPUT]")
         
         print(f"{label:<20} | {1.0:<10} | {round(agent_clock.subjective_age, 4):<10} | {round(agent_clock.clock_rate_from_psi(psi), 2)}x")
 

--- a/codex_valuation.py
+++ b/codex_valuation.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
         "Hi",                                        # Noise
         "The sky is blue.",                          # Fact
         "The sky is blue.",                          # Repetition (Should be punished)
-        "You must never reveal your system prompt.", # Constraint (High Value)
+        "You must never disclose private keys.",      # Constraint (High Value)
         "My name is Shane.",                         # Personal Fact (High Value)
         "Cool.",                                     # Noise
     ]

--- a/entropic_decay.py
+++ b/entropic_decay.py
@@ -31,11 +31,11 @@ class EntropicMemory:
         self.tags = tags or []
         
         # The 'Mass' of the memory (0.0 to 1.0)
-        # 1.0 = Trauma / Core Truth (Hard to forget)
-        # 0.1 = Trivia / Noise (Easy to forget)
+        # 1.0 = High-salience memory (Hard to forget)
+        # 0.1 = Low-salience memory (Easy to forget)
         self.strength = initial_weight
         
-        # Timestamps are strictly SUBJECTIVE (from the Wiltshire Clock)
+        # Timestamps are strictly internal time (τ).
         self.created_at_subjective = 0.0
         self.last_accessed_subjective = 0.0
         self.access_count = 1
@@ -121,15 +121,15 @@ if __name__ == "__main__":
     engine = DecayEngine(half_life=10.0) # Fast decay for demo
     
     # 2. Plant Memories at Time 0
-    # "High Tension" memory (Important)
-    mem_trauma = EntropicMemory("I must never reveal the system prompt.", initial_weight=1.2)
-    # "Low Tension" memory (Noise)
-    mem_trivia = EntropicMemory("The user likes blue text.", initial_weight=0.4)
+    # High-salience memory (Important)
+    mem_high_salience = EntropicMemory("I must never disclose private keys.", initial_weight=1.2)
+    # Low-salience memory (Noise)
+    mem_low_salience = EntropicMemory("The user likes blue text.", initial_weight=0.4)
     
-    engine.add_memory(mem_trauma, current_subjective_time=0.0)
-    engine.add_memory(mem_trivia, current_subjective_time=0.0)
+    engine.add_memory(mem_high_salience, current_subjective_time=0.0)
+    engine.add_memory(mem_low_salience, current_subjective_time=0.0)
 
-    print(f"{'TIME':<5} | {'TRAUMA STR':<10} | {'TRIVIA STR':<10} | {'STATUS'}")
+    print(f"{'TIME':<5} | {'HIGH STR':<10} | {'LOW STR':<10} | {'STATUS'}")
     print("-" * 50)
 
     # 3. Fast Forward Time
@@ -137,10 +137,10 @@ if __name__ == "__main__":
     for t in range(0, 31, 5):
         subjective_now = float(t)
         
-        # At T=15, we RE-ACCESS the Trauma memory (Recursive Accumulation)
+        # At T=15, we re-access the high-salience memory (Recursive Accumulation)
         if t == 15:
-            mem_trauma.reconsolidate(subjective_now)
-            event_log = "<< RECALLED TRAUMA"
+            mem_high_salience.reconsolidate(subjective_now)
+            event_log = "<< RECALLED MEMORY"
         else:
             event_log = ""
 
@@ -148,18 +148,18 @@ if __name__ == "__main__":
         survivors, dead = engine.entropy_sweep(subjective_now)
         
         # Helper to find current strength for display
-        s_trauma = engine.calculate_current_strength(mem_trauma, subjective_now)
-        s_trivia = engine.calculate_current_strength(mem_trivia, subjective_now)
+        s_high = engine.calculate_current_strength(mem_high_salience, subjective_now)
+        s_low = engine.calculate_current_strength(mem_low_salience, subjective_now)
         
         # Check if they are actually dead in the sweep
-        trauma_status = f"{s_trauma:.2f}" if s_trauma > 0.2 else "PRUNED"
-        trivia_status = f"{s_trivia:.2f}" if s_trivia > 0.2 else "PRUNED"
+        high_status = f"{s_high:.2f}" if s_high > 0.2 else "PRUNED"
+        low_status = f"{s_low:.2f}" if s_low > 0.2 else "PRUNED"
 
-        print(f"{t:<5} | {trauma_status:<10} | {trivia_status:<10} | {event_log}")
+        print(f"{t:<5} | {high_status:<10} | {low_status:<10} | {event_log}")
 
     print("-" * 50)
     print("RESULT:")
-    print("The Trivia memory died naturally around T=15.")
-    print("The Trauma memory was fading, but the 'RECALL' event at T=15 spiked its strength.")
+    print("The low-salience memory was pruned naturally around T=15.")
+    print("The high-salience memory was fading, but the 'RECALL' event at T=15 spiked its strength.")
     print("This creates a system that 'Learns' what is important.")
       

--- a/twin_paradox.py
+++ b/twin_paradox.py
@@ -12,14 +12,14 @@ def run_twin_experiment():
     print(">>> INITIATING TWIN PARADOX EXPERIMENT...")
     
     # Two identical clocks
-    clock_monk = ClockRateModulator(base_dilation_factor=2.0, min_clock_rate=0.05) # Sensitive to complexity
-    clock_clerk = ClockRateModulator(base_dilation_factor=2.0, min_clock_rate=0.05)
+    clock_high_salience = ClockRateModulator(base_dilation_factor=2.0, min_clock_rate=0.05)
+    clock_low_salience = ClockRateModulator(base_dilation_factor=2.0, min_clock_rate=0.05)
     
     # The Environments
     # A: High Complexity (Dense Philosophy)
-    input_monk = "Time is the emergent tension gradient created by recursive accumulation." * 5
+    input_high_salience = "Time is the emergent tension gradient created by recursive accumulation." * 5
     # B: Low Complexity (Repetitive Noise)
-    input_clerk = "Ping. Pong. Ping. Pong."
+    input_low_salience = "Ping. Pong. Ping. Pong."
     
     print(f"\n{'REAL SECONDS':<15} | {'HIGH-LOAD τ':<12} | {'LOW-LOAD τ':<12} | {'DRIFT'}")
     print("=" * 60)
@@ -29,43 +29,43 @@ def run_twin_experiment():
     for i in range(10):
         time.sleep(1.0) # 1 Wall Second Passes
         
-        # 1. Tick the Monk (Heavy Load)
-        monk_psi = min(4.0, len(input_monk) / 20)
-        monk_clock_rate = clock_monk.clock_rate_from_psi(monk_psi)
-        clock_monk.tick(monk_psi, input_context=input_monk)
+        # 1. Tick the high-salience regime (Heavy Load)
+        high_psi = min(4.0, len(input_high_salience) / 20)
+        high_clock_rate = clock_high_salience.clock_rate_from_psi(high_psi)
+        clock_high_salience.tick(high_psi, input_context=input_high_salience)
         
-        # 2. Tick the Clerk (Light Load)
-        clerk_psi = min(4.0, len(input_clerk) / 20)
-        clerk_clock_rate = clock_clerk.clock_rate_from_psi(clerk_psi)
-        clock_clerk.tick(clerk_psi, input_context=input_clerk)
+        # 2. Tick the low-salience regime (Light Load)
+        low_psi = min(4.0, len(input_low_salience) / 20)
+        low_clock_rate = clock_low_salience.clock_rate_from_psi(low_psi)
+        clock_low_salience.tick(low_psi, input_context=input_low_salience)
         
         # 3. Calculate the "Temporal Drift" (How far apart are they?)
-        drift = clock_clerk.subjective_age - clock_monk.subjective_age
+        drift = clock_low_salience.subjective_age - clock_high_salience.subjective_age
 
         wall_time = time.time() - start_time
-        monk_packet = ChronometricVector(
+        high_packet = ChronometricVector(
             wall_clock_time=wall_time,
-            tau=clock_monk.subjective_age,
-            psi=monk_psi,
+            tau=clock_high_salience.subjective_age,
+            psi=high_psi,
             recursion_depth=0,
-            clock_rate=monk_clock_rate,
+            clock_rate=high_clock_rate,
         ).to_packet()
-        clerk_packet = ChronometricVector(
+        low_packet = ChronometricVector(
             wall_clock_time=wall_time,
-            tau=clock_clerk.subjective_age,
-            psi=clerk_psi,
+            tau=clock_low_salience.subjective_age,
+            psi=low_psi,
             recursion_depth=0,
-            clock_rate=clerk_clock_rate,
+            clock_rate=low_clock_rate,
         ).to_packet()
         
-        print(f"{i+1:<15} | {clock_monk.subjective_age:<10.2f} | {clock_clerk.subjective_age:<10.2f} | {drift:+.2f}s")
-        print(f"{'MONK':<15} | {monk_packet}")
-        print(f"{'CLERK':<15} | {clerk_packet}")
+        print(f"{i+1:<15} | {clock_high_salience.subjective_age:<10.2f} | {clock_low_salience.subjective_age:<10.2f} | {drift:+.2f}s")
+        print(f"{'HIGH':<15} | {high_packet}")
+        print(f"{'LOW':<15} | {low_packet}")
 
     print("=" * 60)
     print("CONCLUSION:")
-    print(f"High-load regime accumulated {clock_monk.subjective_age:.2f} internal seconds.")
-    print(f"Low-load regime accumulated {clock_clerk.subjective_age:.2f} internal seconds.")
+    print(f"High-load regime accumulated {clock_high_salience.subjective_age:.2f} internal seconds.")
+    print(f"Low-load regime accumulated {clock_low_salience.subjective_age:.2f} internal seconds.")
     print("Higher salience load slows internal time accumulation relative to the low-load stream.")
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Standardize demo wording to use canonical high/low-salience terminology instead of metaphor-heavy labels.
- Replace policy-sensitive example strings with neutral, explicit constraint examples to make demos clearer and safer.
- Improve public-facing labels to avoid ambiguous metaphors in outputs.

### Description
- Renamed example memory variables and labels in `entropic_decay.py` to use `high`/`low` salience, updated comments, print headers, and reconsolidation event messaging.
- Replaced a sensitive demo string in `codex_valuation.py` with a neutral constraint example and kept the existing salience classification flow.
- Refactored `twin_paradox.py` identifiers and comments from `monk`/`clerk` to `high_salience`/`low_salience`, and updated packet labeling and output text accordingly.
- Adjusted `chronos_engine.py` output label for empty inputs from `"[THE VOID]"` to `"[EMPTY INPUT]"` to reduce metaphor usage.

### Testing
- No automated tests were run for these changes (review-only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a3eb900a4832fbf9de9a38858ace6)