### PR TITLE
Restructure glossary to isolate deprecated terms

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -3,15 +3,28 @@
 This glossary defines the **only canonical terminology** for public documentation,
 telemetry, and specifications in this repository.
 
-| Deprecated term (do not use) | Canonical replacement | Notes |
-| --- | --- | --- |
-| Subjective Experience Metrics | **Internal State Telemetry** | Logged outputs of internal \(\tau\), salience load, and memory strength. No claims about experience. |
-| Subjective Time | **Internal Time Accumulator (\(\tau\))** | Integrated internal coordinate driven by clock-rate reparameterization. Internal time unit; **not age**. |
-| Wiltshire Transformation / Time Dilation | **Clock-rate Reparameterization** | Maps salience load \(\Psi\) to \(d\tau/dt\); implemented in the clock-rate modulator with explicit floor/clamp. |
-| Semantic Density | **Salience Load (Surprise×Value)** | Product of normalized novelty and imperative weight; drives clock-rate changes. |
-| Singularity / Trauma | **High-salience event** | Input with outsized salience load; described operationally without moral framing. |
-| Monk / Clerk | **High-salience regime / Low-salience regime** | Processing contexts with high vs. low salience load. |
-| Death of memory | **Pruned / Decayed below threshold** | Memory removed after falling below the retention threshold. |
+| Canonical term | Notes |
+| --- | --- |
+| **Internal State Telemetry** | Logged outputs of internal \(\tau\), salience load, and memory strength. No claims about experience. |
+| **Internal Time Accumulator (\(\tau\))** | Integrated internal coordinate driven by clock-rate reparameterization. Internal time unit; **not age**. |
+| **Clock-rate Reparameterization** | Maps salience load \(\Psi\) to \(d\tau/dt\); implemented in the clock-rate modulator with explicit floor/clamp. |
+| **Salience Load (Surprise×Value)** | Product of normalized novelty and imperative weight; drives clock-rate changes. |
+| **High-salience event** | Input with outsized salience load; described operationally without moral framing. |
+| **High-salience regime / Low-salience regime** | Processing contexts with high vs. low salience load. |
+| **Pruned / Decayed below threshold** | Memory removed after falling below the retention threshold. |
+
+## Deprecated terms (internal only; exclude from public demos/outputs)
+Deprecated terms are preserved here strictly for legacy reference and migration. Do not surface these in public outputs.
+
+| Deprecated term (do not use) | Canonical replacement |
+| --- | --- |
+| Subjective Experience Metrics | **Internal State Telemetry** |
+| Subjective Time | **Internal Time Accumulator (\(\tau\))** |
+| Wiltshire Transformation / Time Dilation | **Clock-rate Reparameterization** |
+| Semantic Density | **Salience Load (Surprise×Value)** |
+| Singularity / Trauma | **High-salience event** |
+| Monk / Clerk | **High-salience regime / Low-salience regime** |
+| Death of memory | **Pruned / Decayed below threshold** |
 
 ## Terminology Enforcement Rules
 - Deprecated terms **must not** appear in:


### PR DESCRIPTION
### Motivation
- Ensure the main public glossary contains only canonical terminology and prevent legacy/metaphorical labels from appearing in public docs and telemetry by moving them to an internal appendix in `GLOSSARY.md`.

### Description
- Replace the primary glossary table with a canonical-only table and add a clearly marked "Deprecated terms (internal only)" appendix that preserves legacy-to-canonical mappings in `GLOSSARY.md`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4855f818832fa98d4602fe478623)