### PR TITLE
Adopt canonical telemetry keys and align simulation headers

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -5,17 +5,17 @@ The Temporal Gradient outputs **Internal State Telemetry** rather than conventio
 This table shows how the internal clock-rate is reparameterized by salience load (surprise × value).
 
 ```text
-WALL T   | INTERNAL τ | INPUT                               | PRIORITY | CLOCK RATE (dτ/dt)
+WALL_T   | TAU | INPUT                               | SALIENCE | CLOCK_RATE (dτ/dt)
 ============================================================================================
 1.0      | 0.15       | "CRITICAL: SECURITY BREACH..."      | 1.5      | 0.15x
 2.0      | 1.15       | "Checking local weather..."         | 0.4      | 1.00x
 ```
 
 Key metrics:
-- **WALL T:** External time elapsed (seconds).
-- **INTERNAL τ:** Internal time accumulator after clock-rate reparameterization.
-- **PRIORITY:** Surprise×value score from the valuator.
-- **CLOCK RATE (dτ/dt):** Internal clock multiplier after salience modulation.
+- **WALL_T:** External time elapsed (seconds).
+- **TAU:** Internal time accumulator after clock-rate reparameterization.
+- **SALIENCE:** Surprise×value score from the valuator.
+- **CLOCK_RATE (dτ/dt):** Internal clock multiplier after salience modulation.
 
 Interpretation:
 - A CLOCK RATE below 1.0x means the internal clock slowed to process a high-load event (reduced internal clock rate), not “bullet time.”
@@ -30,7 +30,7 @@ At the end of the simulation, the decay engine reports which memories stayed abo
 [DEAD ] Content: "Rain. Water. Liquid."
 ```
 
-- **ALIVE:** The memory stayed above the pruning threshold because it started with a high priority or was reconsolidated.
+- **ALIVE:** The memory stayed above the pruning threshold because it started with high salience or was reconsolidated.
 - **DEAD:** The memory decayed below the threshold and was pruned.
 
 ## 3. Configuration hints

--- a/chronometric_vector.py
+++ b/chronometric_vector.py
@@ -22,6 +22,7 @@ class ChronometricVector:
     clock_rate: Optional[float] = None
     H: Optional[float] = None
     V: Optional[float] = None
+    memory_strength: Optional[float] = None
     entropy_cost: float = 0.0  # How much energy did this thought burn?
 
     def to_packet(self):
@@ -29,30 +30,33 @@ class ChronometricVector:
         Serializes the vector for transmission.
         """
         packet = {
-            "t_obj": round(self.wall_clock_time, 2),
-            "tau": round(self.tau, 2),
-            "psi": round(self.psi, 3), # Salience load
-            "r": self.recursion_depth
+            "WALL_T": round(self.wall_clock_time, 2),
+            "TAU": round(self.tau, 2),
+            "SALIENCE": round(self.psi, 3), # Salience load
+            "DEPTH": self.recursion_depth,
         }
         if self.clock_rate is not None:
-            packet["clock_rate"] = round(self.clock_rate, 4)
+            packet["CLOCK_RATE"] = round(self.clock_rate, 4)
         if self.H is not None:
             packet["H"] = round(self.H, 4)
         if self.V is not None:
             packet["V"] = round(self.V, 4)
+        if self.memory_strength is not None:
+            packet["MEMORY_S"] = round(self.memory_strength, 4)
         return json.dumps(packet)
 
     @staticmethod
     def from_packet(json_str):
         data = json.loads(json_str)
-        psi = data.get('psi', data.get('semantic_density'))
+        psi = data.get('SALIENCE')
         return ChronometricVector(
-            wall_clock_time=data['t_obj'],
-            tau=data['tau'],
+            wall_clock_time=data['WALL_T'],
+            tau=data['TAU'],
             psi=psi,
-            recursion_depth=data['r'],
-            clock_rate=data.get('clock_rate'),
+            recursion_depth=data.get('DEPTH', 0),
+            clock_rate=data.get('CLOCK_RATE'),
             H=data.get('H'),
             V=data.get('V'),
-            entropy_cost=data.get('entropy_cost', 0.0)
+            memory_strength=data.get('MEMORY_S', data.get('S')),
+            entropy_cost=data.get('entropy_cost', 0.0),
         )

--- a/simulation_run.py
+++ b/simulation_run.py
@@ -37,7 +37,7 @@ def run_simulation():
         "System standby."
     ]
 
-    print(f"\n{'WALL T':<8} | {'INTERNAL τ':<12} | {'INPUT':<35} | {'PRIO':<4} | {'CLOCK RATE'}")
+    print(f"\n{'WALL_T':<8} | {'TAU':<12} | {'INPUT':<35} | {'SALIENCE':<8} | {'CLOCK_RATE'}")
     print("=" * 85)
 
     start_time = time.time()
@@ -75,7 +75,7 @@ def run_simulation():
         packet = vector.to_packet()
 
         # E. Print Status
-        print(f"{1.0 * (i+1):<8} | {subjective_now:<12.2f} | {text[:35]:<35} | {sal.psi:<4.1f} | {dilation:.2f}x")
+        print(f"{1.0 * (i+1):<8} | {subjective_now:<12.2f} | {text[:35]:<35} | {sal.psi:<8.3f} | {dilation:.2f}x")
         print(f"{'PACKET':<8} | {packet}")
 
     print("=" * 85)

--- a/twin_paradox.py
+++ b/twin_paradox.py
@@ -21,8 +21,11 @@ def run_twin_experiment():
     # B: Low Complexity (Repetitive Noise)
     input_low_salience = "Ping. Pong. Ping. Pong."
     
-    print(f"\n{'REAL SECONDS':<15} | {'HIGH-LOAD τ':<12} | {'LOW-LOAD τ':<12} | {'DRIFT'}")
-    print("=" * 60)
+    print(
+        f"\n{'WALL_T':<8} | {'TAU_HIGH':<10} | {'TAU_LOW':<10} | "
+        f"{'SALIENCE_H':<11} | {'SALIENCE_L':<11} | {'CLOCK_RATE_H':<13} | {'CLOCK_RATE_L':<13} | {'DRIFT'}"
+    )
+    print("=" * 110)
     
     # Run for 10 "Real" Seconds
     start_time = time.time()
@@ -49,6 +52,8 @@ def run_twin_experiment():
             psi=high_psi,
             recursion_depth=0,
             clock_rate=high_clock_rate,
+            H=0.0,
+            V=0.0,
         ).to_packet()
         low_packet = ChronometricVector(
             wall_clock_time=wall_time,
@@ -56,13 +61,18 @@ def run_twin_experiment():
             psi=low_psi,
             recursion_depth=0,
             clock_rate=low_clock_rate,
+            H=0.0,
+            V=0.0,
         ).to_packet()
         
-        print(f"{i+1:<15} | {clock_high_salience.subjective_age:<10.2f} | {clock_low_salience.subjective_age:<10.2f} | {drift:+.2f}s")
+        print(
+            f"{i+1:<8} | {clock_high_salience.subjective_age:<10.2f} | {clock_low_salience.subjective_age:<10.2f} | "
+            f"{high_psi:<11.3f} | {low_psi:<11.3f} | {high_clock_rate:<13.4f} | {low_clock_rate:<13.4f} | {drift:+.2f}s"
+        )
         print(f"{'HIGH':<15} | {high_packet}")
         print(f"{'LOW':<15} | {low_packet}")
 
-    print("=" * 60)
+    print("=" * 110)
     print("CONCLUSION:")
     print(f"High-load regime accumulated {clock_high_salience.subjective_age:.2f} internal seconds.")
     print(f"Low-load regime accumulated {clock_low_salience.subjective_age:.2f} internal seconds.")


### PR DESCRIPTION
### Motivation
- Enforce the repository's canonical telemetry schema (WALL_T/TAU/SALIENCE/CLOCK_RATE/MEMORY_S/DEPTH) and remove legacy/deprecated telemetry labels from packets and CLI output. 
- Ensure demo scripts emit a consistent packet payload (including {H, V, psi, clock_rate, tau}) so downstream logging and tooling can rely on a single schema.

### Description
- Update `ChronometricVector.to_packet`/`from_packet` to emit and consume canonical keys: `WALL_T`, `TAU`, `SALIENCE`, `DEPTH`, `CLOCK_RATE`, and `MEMORY_S`, and add a `memory_strength` field to the dataclass. 
- Replace legacy packet fields (`t_obj`, `r`, `semantic_density`) with the canonical names and adjust parsing to read the new keys. 
- Align CLI/table headers and print formatting in `simulation_run.py` to `WALL_T`/`TAU`/`SALIENCE`/`CLOCK_RATE` and tighten the printed numeric formatting. 
- Expand `twin_paradox.py` header to include salience/clock-rate columns and ensure both twin packets emit `H` and `V` telemetry while using the canonical packet schema. 
- Update `USAGE.md` to reflect canonical column names and replace “PRIORITY/PRIO” phrasing with `SALIENCE`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4a480cc4832facb6cfe78096bda0)