### PR TITLE
Add `salience_mode` to ClockRateModulator; enforce canonical psi-only ticks with legacy density fallback

### DIFF
--- a/chronometric_vector.py
+++ b/chronometric_vector.py
@@ -46,9 +46,13 @@ class ChronometricVector:
         return json.dumps(packet)
 
     @staticmethod
-    def from_packet(json_str):
+    def from_packet(json_str, salience_mode="canonical"):
         data = json.loads(json_str)
+        if salience_mode not in {"canonical", "legacy_density"}:
+            raise ValueError("salience_mode must be 'canonical' or 'legacy_density'.")
         psi = data.get('SALIENCE')
+        if psi is None and salience_mode == "legacy_density":
+            psi = data.get('semantic_density', data.get('SEMANTIC_DENSITY'))
         return ChronometricVector(
             wall_clock_time=data['WALL_T'],
             tau=data['TAU'],

--- a/simulation_run.py
+++ b/simulation_run.py
@@ -49,8 +49,7 @@ def run_simulation():
         sal = salience.evaluate(text)
         
         # B. Clock tick (clock-rate reparameterization)
-        # We pass the text so the clock can estimate salience load of the moment
-        clock.tick(sal.psi, input_context=text)
+        clock.tick(sal.psi)
         subjective_now = clock.subjective_age
         dilation = clock.clock_rate_from_psi(sal.psi)
         

--- a/twin_paradox.py
+++ b/twin_paradox.py
@@ -35,12 +35,12 @@ def run_twin_experiment():
         # 1. Tick the high-salience regime (Heavy Load)
         high_psi = min(4.0, len(input_high_salience) / 20)
         high_clock_rate = clock_high_salience.clock_rate_from_psi(high_psi)
-        clock_high_salience.tick(high_psi, input_context=input_high_salience)
+        clock_high_salience.tick(high_psi)
         
         # 2. Tick the low-salience regime (Light Load)
         low_psi = min(4.0, len(input_low_salience) / 20)
         low_clock_rate = clock_low_salience.clock_rate_from_psi(low_psi)
-        clock_low_salience.tick(low_psi, input_context=input_low_salience)
+        clock_low_salience.tick(low_psi)
         
         # 3. Calculate the "Temporal Drift" (How far apart are they?)
         drift = clock_low_salience.subjective_age - clock_high_salience.subjective_age


### PR DESCRIPTION
### Motivation
- Make clock-rate behavior explicit by introducing a `salience_mode` so the engine can run in a strict `canonical` mode where `tick()` requires an explicit `psi` and does not compute density, while preserving a `legacy_density` mode for backwards compatibility.
- Prevent implicit use of density-derived salience in modern code paths by removing the unconditional `semantic_density` fallback when reconstructing `ChronometricVector` from a packet.
- Update simulation entrypoints and demos to use the canonical `psi`-only `tick()` call pattern.

### Description
- Add a `salience_mode` parameter and `_validate_salience_mode()` to `ClockRateModulator`, change `tick()` signature to `tick(self, psi=None, input_context=None)`, enforce that `psi` must be provided in `canonical` mode, and only derive `psi` from `calculate_information_density()` when `salience_mode == "legacy_density"`; diagnostic density telemetry is emitted only in legacy mode (`chronos_engine.py`).
- Replace calls that passed `input_context` to `tick()` with `tick(sal.psi)` in `simulation_run.py`, `twin_paradox.py`, and the `chronos_engine` demo loop to reflect canonical usage.
- Add a `salience_mode` parameter to `ChronometricVector.from_packet()` and gate the `semantic_density`/`SEMANTIC_DENSITY` fallback behind `salience_mode == "legacy_density"` (`chronometric_vector.py`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4bb34f88832faaa8f65ef5d9ea2f)