### PR TITLE
Replace deprecated temporal terminology with canonical `tau` and update outputs

### DIFF
--- a/chronos_engine.py
+++ b/chronos_engine.py
@@ -14,7 +14,7 @@ class ClockRateModulator:
     
     def __init__(self, base_dilation_factor=1.0, min_clock_rate=0.05, salience_mode="canonical"):
         self.start_wall_time = time.time()
-        self.subjective_age = 0.0
+        self.tau = 0.0
         self.base_dilation = base_dilation_factor
         self.min_clock_rate = min_clock_rate
         self.last_tick = self.start_wall_time
@@ -80,16 +80,16 @@ class ClockRateModulator:
         clock_rate = self.clock_rate_from_psi(psi)
         
         # Calculate tau Delta
-        subjective_delta = wall_delta * clock_rate
-        self.subjective_age += subjective_delta
+        tau_delta = wall_delta * clock_rate
+        self.tau += tau_delta
 
         # Log the state
         telemetry = {
             "wall_delta": round(wall_delta, 4),
-            "tau": round(self.subjective_age, 4),
+            "tau": round(self.tau, 4),
             "psi": round(psi, 4),
             "clock_rate": round(clock_rate, 4),
-            "d_tau": round(subjective_delta, 4)
+            "d_tau": round(tau_delta, 4)
         }
         if density is not None:
             telemetry["diagnostic_density"] = round(density, 2)
@@ -97,7 +97,7 @@ class ClockRateModulator:
         
         self.last_tick = current_wall_time
         
-        return subjective_delta
+        return tau_delta
 
 # --- SIMULATION ---
 
@@ -130,7 +130,7 @@ if __name__ == "__main__":
         
         label = (event[:15] + '...') if len(event) > 15 else (event if event else "[EMPTY INPUT]")
         
-        print(f"{label:<20} | {1.0:<10} | {round(agent_clock.subjective_age, 4):<10} | {round(agent_clock.clock_rate_from_psi(psi), 2)}x")
+        print(f"{label:<20} | {1.0:<10} | {round(agent_clock.tau, 4):<10} | {round(agent_clock.clock_rate_from_psi(psi), 2)}x")
 
     print("-" * 60)
     print("OBSERVATION:")

--- a/simulation_run.py
+++ b/simulation_run.py
@@ -50,7 +50,7 @@ def run_simulation():
         
         # B. Clock tick (clock-rate reparameterization)
         clock.tick(sal.psi)
-        subjective_now = clock.subjective_age
+        tau_now = clock.tau
         dilation = clock.clock_rate_from_psi(sal.psi)
         
         # C. Encode memory
@@ -58,13 +58,13 @@ def run_simulation():
         if should_encode(sal.psi, threshold=0.3):
             strength = initial_strength_from_psi(sal.psi, S_max=1.2)
             mem = EntropicMemory(text, initial_weight=strength)
-            decay.add_memory(mem, subjective_now)
+            decay.add_memory(mem, tau_now)
             
         # D. Emit Chronometric Packet
         wall_time = time.time() - start_time
         vector = ChronometricVector(
             wall_clock_time=wall_time,
-            tau=subjective_now,
+            tau=tau_now,
             psi=sal.psi,
             recursion_depth=0,
             clock_rate=dilation,
@@ -74,15 +74,15 @@ def run_simulation():
         packet = vector.to_packet()
 
         # E. Print Status
-        print(f"{1.0 * (i+1):<8} | {subjective_now:<12.2f} | {text[:35]:<35} | {sal.psi:<8.3f} | {dilation:.2f}x")
+        print(f"{1.0 * (i+1):<8} | {tau_now:<12.2f} | {text[:35]:<35} | {sal.psi:<8.3f} | {dilation:.2f}x")
         print(f"{'PACKET':<8} | {packet}")
 
     print("=" * 85)
     print(">>> MEMORY AUDIT (Post-Simulation)")
     
     # F. Check what survived
-    current_subj_time = clock.subjective_age
-    survivors, dead = decay.entropy_sweep(current_subj_time)
+    current_tau = clock.tau
+    survivors, dead = decay.entropy_sweep(current_tau)
     
     for mem, str_val in survivors:
         print(f"[ALIVE] Strength: {str_val:.2f} | Content: {mem.content}")

--- a/twin_paradox.py
+++ b/twin_paradox.py
@@ -43,12 +43,12 @@ def run_twin_experiment():
         clock_low_salience.tick(low_psi)
         
         # 3. Calculate the "Temporal Drift" (How far apart are they?)
-        drift = clock_low_salience.subjective_age - clock_high_salience.subjective_age
+        drift = clock_low_salience.tau - clock_high_salience.tau
 
         wall_time = time.time() - start_time
         high_packet = ChronometricVector(
             wall_clock_time=wall_time,
-            tau=clock_high_salience.subjective_age,
+            tau=clock_high_salience.tau,
             psi=high_psi,
             recursion_depth=0,
             clock_rate=high_clock_rate,
@@ -57,7 +57,7 @@ def run_twin_experiment():
         ).to_packet()
         low_packet = ChronometricVector(
             wall_clock_time=wall_time,
-            tau=clock_low_salience.subjective_age,
+            tau=clock_low_salience.tau,
             psi=low_psi,
             recursion_depth=0,
             clock_rate=low_clock_rate,
@@ -66,7 +66,7 @@ def run_twin_experiment():
         ).to_packet()
         
         print(
-            f"{i+1:<8} | {clock_high_salience.subjective_age:<10.2f} | {clock_low_salience.subjective_age:<10.2f} | "
+            f"{i+1:<8} | {clock_high_salience.tau:<10.2f} | {clock_low_salience.tau:<10.2f} | "
             f"{high_psi:<11.3f} | {low_psi:<11.3f} | {high_clock_rate:<13.4f} | {low_clock_rate:<13.4f} | {drift:+.2f}s"
         )
         print(f"{'HIGH':<15} | {high_packet}")
@@ -74,8 +74,8 @@ def run_twin_experiment():
 
     print("=" * 110)
     print("CONCLUSION:")
-    print(f"High-load regime accumulated {clock_high_salience.subjective_age:.2f} internal seconds.")
-    print(f"Low-load regime accumulated {clock_low_salience.subjective_age:.2f} internal seconds.")
+    print(f"High-load regime accumulated {clock_high_salience.tau:.2f} internal seconds.")
+    print(f"Low-load regime accumulated {clock_low_salience.tau:.2f} internal seconds.")
     print("Higher salience load slows internal time accumulation relative to the low-load stream.")
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Migrate deprecated subjective temporal terms to the canonical vocabulary defined in `GLOSSARY.md`, primarily replacing internal `subjective_age`/`subjective` naming with `tau` and using canonical phrases like "clock-rate reparameterization" and "salience load" in code and CLI output.
- Ensure runtime telemetry, printed summaries, and memory-timestamp APIs expose only the canonical internal-time vocabulary to align public outputs with repository terminology rules.
- Apply consistent renames across clock, decay engine, and simulation scripts to avoid mixed terminology and reduce future confusion.

### Description
- Renamed the internal accumulator and API surface in `ClockRateModulator` from `subjective_age` to `tau`, updated the tick return variable to `tau_delta`, and adjusted telemetry keys to report `tau` and `d_tau`.
- Updated `entropic_decay.py` to replace `created_at_subjective`/`last_accessed_subjective` and `current_subjective_time` with `created_at_tau`/`last_accessed_tau` and `current_tau`, and updated related comments to reference internal time (τ) and clock-rate reparameterization.
- Updated `simulation_run.py` to use `tau_now = clock.tau`, pass `tau` into `DecayEngine` calls and `ChronometricVector`, and to print `TAU` in the CLI table.
- Updated `twin_paradox.py` to compute drift and packets using `tau` and to print `TAU_HIGH`/`TAU_LOW` and summary lines using the canonical `tau` naming.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4e081028832fb7965a2d64756f43)