### PR TITLE
Add pytest coverage for clock-rate, salience pipeline, and entropic decay invariants

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_clock_rate_modulator.py
+++ b/tests/test_clock_rate_modulator.py
@@ -1,0 +1,18 @@
+import math
+
+from chronos_engine import ClockRateModulator
+
+
+def test_clock_rate_monotonic_and_floor():
+    modulator = ClockRateModulator(base_dilation_factor=1.0, min_clock_rate=0.05)
+    psis = [0.0, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0]
+    rates = [modulator.clock_rate_from_psi(psi) for psi in psis]
+
+    for earlier, later in zip(rates, rates[1:]):
+        assert later <= earlier
+
+    assert rates[0] == 1.0
+    assert all(rate >= modulator.min_clock_rate for rate in rates)
+
+    high_rate = modulator.clock_rate_from_psi(1e6)
+    assert math.isclose(high_rate, modulator.min_clock_rate)

--- a/tests/test_entropic_decay.py
+++ b/tests/test_entropic_decay.py
@@ -1,0 +1,31 @@
+import math
+
+from entropic_decay import DecayEngine, EntropicMemory
+
+
+def test_decay_strength_nonincreasing_over_time():
+    memory = EntropicMemory("stable", initial_weight=1.0)
+    memory.last_accessed_tau = 0.0
+    engine = DecayEngine(half_life=10.0)
+
+    strengths = [engine.calculate_current_strength(memory, tau) for tau in (0.0, 5.0, 10.0, 20.0)]
+    for earlier, later in zip(strengths, strengths[1:]):
+        assert later <= earlier
+
+
+def test_reconsolidation_capped():
+    memory = EntropicMemory("cap", initial_weight=1.4)
+
+    for step in range(1, 40):
+        memory.reconsolidate(current_tau=float(step), cooldown=0.0)
+
+    assert memory.strength <= 1.5
+
+
+def test_reconsolidation_cooldown_enforced():
+    memory = EntropicMemory("cooldown", initial_weight=1.0)
+    initial_strength = memory.strength
+
+    strength_after = memory.reconsolidate(current_tau=0.5, cooldown=1.0)
+
+    assert math.isclose(strength_after, initial_strength)

--- a/tests/test_salience_pipeline.py
+++ b/tests/test_salience_pipeline.py
@@ -1,0 +1,18 @@
+import math
+
+from salience_pipeline import KeywordImperativeValue, RollingJaccardNovelty, SaliencePipeline
+
+
+def test_salience_pipeline_bounds_and_product():
+    novelty = RollingJaccardNovelty(window_size=3)
+    value = KeywordImperativeValue(keywords=["must"], base_value=0.2, hit_value=0.3, max_value=1.0)
+    pipeline = SaliencePipeline(novelty, value)
+
+    first = pipeline.evaluate("We must always test our pipeline.")
+    second = pipeline.evaluate("We must always test our pipeline.")
+
+    for result in (first, second):
+        assert 0.0 <= result.novelty <= 1.0
+        assert 0.0 <= result.value <= 1.0
+        assert 0.0 <= result.psi <= 1.0
+        assert math.isclose(result.psi, result.novelty * result.value, rel_tol=1e-9)


### PR DESCRIPTION
### Motivation
- Provide deterministic unit tests for core temporal and salience invariants to prevent regressions in clock-rate mapping, salience composition, and memory decay behavior.
- Ensure tests are stable and avoid wall-clock sleeps by using fixed inputs and internal-time APIs.

### Description
- Add `tests/test_clock_rate_modulator.py` to validate `ClockRateModulator.clock_rate_from_psi()` is monotonic with respect to `psi` and honors the `min_clock_rate` floor.
- Add `tests/test_salience_pipeline.py` to assert `SaliencePipeline.evaluate()` returns `H`, `V`, and `psi` within `[0,1]` and that `psi == H * V` within numerical tolerance using `RollingJaccardNovelty` and `KeywordImperativeValue`.
- Add `tests/test_entropic_decay.py` to cover `DecayEngine.calculate_current_strength()` monotonicity over increasing `tau`, reconsolidation capping (strength ≤ 1.5), and cooldown enforcement in `EntropicMemory.reconsolidate()`.
- Add `tests/conftest.py` which inserts the repository root on `sys.path` so local modules (`chronos_engine`, `salience_pipeline`, `entropic_decay`) can be imported by the tests.

### Testing
- Ran `pytest -q` and all tests succeeded with `5 passed` (run shown as `5 passed in 0.03s`).
- Tests use stable, deterministic inputs and do not rely on sleeping or wall-clock timing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4f1459c8832fa6ed0b47d1a445a3)