### PR TITLE
Clarify telemetry INPUT usage, normalize headers, and use S_MAX in decay test

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ S(\tau_k^+)=\min(S_{\max}, S(\tau_k^-)+\Delta_k)
 ## Telemetry Schema (key columns)
 - **WALL_T**: wall time (seconds)
 - **TAU**: internal time accumulator \(\tau\)
-- **INPUT**: processed input identifier (text or key)
 - **SALIENCE**: \(\Psi(t)\) (surprise×value)
 - **CLOCK_RATE**: \(d\tau/dt\)
 - **MEMORY_S**: current memory strength \(S\)
 - **DEPTH**: recursion depth (if used)
+
+Some CLI tables include an **INPUT** column for readability; it is not part of the packet payload.
 
 ## Review-Only Notice
 Per LICENSE, this repository is provided for educational and academic review.  

--- a/USAGE.md
+++ b/USAGE.md
@@ -17,7 +17,7 @@ The telemetry packet is versioned and split into **required** vs **optional** ke
 - `H`
 - `V`
 
-CLI tables should print **only canonical columns** by default (`WALL_T`, `TAU`, `SALIENCE`, `CLOCK_RATE`, `MEMORY_S`, `DEPTH`). Extended fields like `H` and `V` are intended for verbose/debug output, not the base schema.
+CLI tables should print **only canonical columns** by default (`WALL_T`, `TAU`, `SALIENCE`, `CLOCK_RATE`, `MEMORY_S`, `DEPTH`). Extended fields like `H` and `V` are intended for verbose/debug output, not the base schema. Demo scripts may also include an `INPUT` column for readability; it is not part of the canonical packet schema.
 
 ## 1. The clock-rate table
 This table shows how the internal clock-rate is reparameterized by salience load (surprise × value).

--- a/simulation_run.py
+++ b/simulation_run.py
@@ -37,7 +37,7 @@ def run_simulation():
         "System standby."
     ]
 
-    print(f"\n{'WALL_T':<8} | {'TAU':<12} | {'INPUT':<35} | {'SALIENCE':<8} | {'CLOCK_RATE'}")
+    print(f"\n{'WALL_T':<8} | {'TAU':<12} | {'INPUT (CLI)':<35} | {'SALIENCE':<8} | {'CLOCK_RATE'}")
     print("=" * 85)
 
     start_time = time.time()

--- a/tests/test_entropic_decay.py
+++ b/tests/test_entropic_decay.py
@@ -1,6 +1,6 @@
 import math
 
-from entropic_decay import DecayEngine, EntropicMemory
+from entropic_decay import DecayEngine, EntropicMemory, S_MAX
 
 
 def test_decay_strength_nonincreasing_over_time():
@@ -19,7 +19,7 @@ def test_reconsolidation_capped():
     for step in range(1, 40):
         memory.reconsolidate(current_tau=float(step), cooldown=0.0)
 
-    assert memory.strength <= 1.5
+    assert memory.strength <= S_MAX
 
 
 def test_reconsolidation_cooldown_enforced():

--- a/twin_paradox.py
+++ b/twin_paradox.py
@@ -26,8 +26,9 @@ def run_twin_experiment():
     input_low_salience = "Ping. Pong. Ping. Pong."
     
     print(
-        f"\n{'WALL_T':<8} | {'TAU_HIGH':<10} | {'TAU_LOW':<10} | "
-        f"{'SALIENCE_H':<11} | {'SALIENCE_L':<11} | {'CLOCK_RATE_H':<13} | {'CLOCK_RATE_L':<13} | {'DRIFT'}"
+        f"\n{'WALL_T':<8} | {'TAU(HIGH)':<10} | {'TAU(LOW)':<10} | "
+        f"{'SALIENCE(HIGH)':<14} | {'SALIENCE(LOW)':<13} | "
+        f"{'CLOCK_RATE(HIGH)':<16} | {'CLOCK_RATE(LOW)':<15} | {'DRIFT'}"
     )
     print("=" * 110)
     


### PR DESCRIPTION
### Motivation
- Resolve ambiguity where `INPUT` was presented as a canonical packet key when it is only a CLI convenience.
- Preserve canonical telemetry keys while still indicating high/low regimes in human-readable experiment output.
- Remove a magic constant from tests by making the test assert against the exported `S_MAX` invariant.

### Description
- Remove `INPUT` from the packet keys list in `README.md` and add the sentence that `INPUT` is a CLI-only column. 
- Update `USAGE.md` to state that demos may show an `INPUT` column but that it is not part of the canonical packet schema. 
- Label the simulation table header as `INPUT (CLI)` in `simulation_run.py` and update `twin_paradox.py` headers to use canonical names with regime qualifiers like `TAU(HIGH)` / `TAU(LOW)` and `SALIENCE(HIGH)` / `SALIENCE(LOW)` for readability. 
- Update `tests/test_entropic_decay.py` to import `S_MAX` from `entropic_decay` and assert `memory.strength <= S_MAX` instead of using a hard-coded constant.

### Testing
- The entropic-decay test was updated to reference `S_MAX`, but the test suite was not executed as part of this change. 
- No automated CI or unit test runs were performed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a6354afc4832fb79f2df2c53c26c2)