### PR TITLE
Rename codex valuation CLI header to INPUT_CLI

### DIFF
--- a/codex_valuation.py
+++ b/codex_valuation.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
         "Cool.",                                     # Noise
     ]
     
-    print(f"{'INPUT':<40} | {'WEIGHT':<10} | {'CLASSIFICATION'}")
+    print(f"{'INPUT_CLI':<40} | {'WEIGHT':<10} | {'CLASSIFICATION'}")
     print("-" * 75)
     
     for i in inputs:


### PR DESCRIPTION
### Motivation
- Align the demo CLI output with the telemetry guidance in `USAGE.md` by making the `INPUT` column explicitly a CLI-only label so it is not confused with the canonical packet schema.

### Description
- Update the header printed by the demo in `codex_valuation.py` to `INPUT_CLI` (change the `print` format string from `'INPUT'` to `'INPUT_CLI'`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a69361350832f9a36ce359a58147b)