### PR TITLE
Install pytest in GitHub Actions pytest workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,21 @@
+name: pytest
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run tests
+        run: pytest -q


### PR DESCRIPTION
### Motivation
- CI runs were failing when `pytest` was not available in the runner environment. 
- Ensure the test job can execute `pytest` reliably on push and pull request events.

### Description
- Add a GitHub Actions workflow file at `.github/workflows/pytest.yml` that runs on `push` and `pull_request` events. 
- Use `actions/checkout@v4` and `actions/setup-python@v5` with `python-version: "3.x"` and upgrade pip via `python -m pip install --upgrade pip`. 
- Install `pytest` explicitly with `pip install pytest`, conditionally install `requirements.txt` if present, and run tests with `pytest -q`.

### Testing
- No automated tests were run because this change only adds/updates a workflow file and the workflow has not executed in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a7c5fed40832fb630738a4b3710be)