### PR TITLE
Update chronometric vector schema forbidden key checks

### DIFF
--- a/tests/test_chronometric_vector_schema.py
+++ b/tests/test_chronometric_vector_schema.py
@@ -27,7 +27,16 @@ def test_round_trip_canonical_packet():
     assert "CLOCK_RATE" in data
     assert "MEMORY_S" in data
     assert "DEPTH" in data
-    for legacy_key in {"t_obj", "r", "semantic_density", "clock_rate", "psi"}:
+    for legacy_key in {
+        "INPUT",
+        "PRIO",
+        "PRIORITY",
+        "clock_rate",
+        "psi",
+        "r",
+        "semantic_density",
+        "t_obj",
+    }:
         assert legacy_key not in data
 
     parsed = ChronometricVector.from_packet(packet, salience_mode="canonical")


### PR DESCRIPTION
### Motivation
- Ensure `ChronometricVector.to_packet()` JSON output does not leak legacy or forbidden fields by expanding the schema test coverage.

### Description
- Modify `tests/test_chronometric_vector_schema.py` to assert that the keys `INPUT`, `PRIO`, `PRIORITY`, `clock_rate`, `psi`, `r`, `semantic_density`, and `t_obj` are absent from the serialized packet produced by `ChronometricVector.to_packet()`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a7f7b1208832f8b4aedbb67c32664)