### PR TITLE
Install pytest in CI, add debug step, and run tests via `python -m pytest`

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,6 +15,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Debug env
+        run: |
+          python -V
+          pip -V
+          pip list
+          ls -la
       - name: Run tests
-        run: pytest -q
+        run: python -m pytest -q


### PR DESCRIPTION
### Motivation
- Fix failing GitHub Actions runs where `pytest` is not installed by default on `ubuntu-latest`, which can surface as `pytest: command not found`, and avoid PATH-related invocation problems by using `python -m pytest`.
- Add a short debug step to surface Python/pip versions and installed packages so CI failures are easier to diagnose.

### Description
- Update `./github/workflows/pytest.yml` to explicitly install pytest with `python -m pip install pytest` during the `Install dependencies` step.
- Add a `Debug env` step that runs `python -V`, `pip -V`, `pip list`, and `ls -la` to show environment details in CI logs.
- Change the test invocation from `pytest -q` to `python -m pytest -q` to avoid PATH edge cases.

### Testing
- No automated tests were executed for this change because it only modifies the CI workflow and will take effect on the next workflow run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a83a4e950832fb5caf9d999467778)