### PR TITLE
Docs: add minimal usage example and align telemetry docs with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,35 @@ S(\tau_k^+)=\min(S_{\max}, S(\tau_k^-)+\Delta_k)
 - **Simulation Examples (`simulation_run.py`, `twin_paradox.py`)**  
   Demonstrations comparing high-salience vs low-salience regimes and their effects on \(\tau\) and \(S\).
 
+## Minimal usage (library-style)
+```python
+from chronos_engine import ClockRateModulator
+from chronometric_vector import ChronometricVector
+from salience_pipeline import RollingJaccardNovelty, KeywordImperativeValue, SaliencePipeline
+
+clock = ClockRateModulator(base_dilation_factor=1.0, min_clock_rate=0.05)
+salience = SaliencePipeline(RollingJaccardNovelty(), KeywordImperativeValue())
+
+text = "CRITICAL: SECURITY BREACH DETECTED."
+sal = salience.evaluate(text)
+
+# Use a fixed wall_delta to avoid relying on real time in a demo.
+clock.tick(psi=sal.psi, wall_delta=1.0)
+
+packet = ChronometricVector(
+    wall_clock_time=1.0,
+    tau=clock.tau,
+    psi=sal.psi,
+    recursion_depth=0,
+    clock_rate=clock.clock_rate_from_psi(sal.psi),
+    H=sal.novelty,
+    V=sal.value,
+    memory_strength=0.0,
+).to_packet()
+
+print(packet)
+```
+
 ## Stability Constraints
 - **Clock floor:** \(d\tau/dt\) clamps to a minimum value so \(\tau\) cannot stall under extreme salience loads.
 - **Reconsolidation diminishing returns:** \(\Delta_k\) decreases as access count rises to avoid runaway reinforcement.

--- a/USAGE.md
+++ b/USAGE.md
@@ -17,6 +17,8 @@ The telemetry packet is versioned and split into **required** vs **optional** ke
 - `H`
 - `V`
 
+`CLOCK_RATE` and `MEMORY_S` are always present in the packet, but may be `null` if they were not set when the packet was created.
+
 CLI tables should print **only canonical columns** by default (`WALL_T`, `TAU`, `SALIENCE`, `CLOCK_RATE`, `MEMORY_S`, `DEPTH`). Extended fields like `H` and `V` are intended for verbose/debug output, not the base schema. Demo scripts may also include an `INPUT` column for readability; it is not part of the canonical packet schema.
 
 ## 1. The clock-rate table
@@ -45,11 +47,11 @@ At the end of the simulation, the decay engine reports which memories stayed abo
 ```
 >>> MEMORY AUDIT (Post-Simulation)
 [ALIVE] Strength: 1.42 | Content: "My name is Sentinel."
-[DEAD ] Content: "Rain. Water. Liquid."
+[PRUNED ] Content: "Rain. Water. Liquid."
 ```
 
 - **ALIVE:** The memory stayed above the pruning threshold because it started with high salience or was reconsolidated.
-- **DEAD:** The memory decayed below the threshold and was pruned.
+- **PRUNED:** The memory decayed below the threshold and was pruned.
 
 ## 3. Configuration hints
 Adjust these parameters in `simulation_run.py` and the supporting modules to shape the simulation:


### PR DESCRIPTION
### Motivation
- The README and USAGE docs contained small mismatches with the runtime behavior of the library (packet fields and memory-audit labels) and lacked a minimal library-style usage snippet to demonstrate the actual API.

### Description
- Added a minimal, library-style example to `README.md` showing `ClockRateModulator`, `SaliencePipeline`, and `ChronometricVector` usage with a fixed `wall_delta` to avoid relying on real time.
- Clarified in `USAGE.md` that `CLOCK_RATE` and `MEMORY_S` are present in the packet but may be `null` when unset by the producer.
- Updated the memory-audit example label from `DEAD` to `PRUNED` in `USAGE.md` to match the simulation output.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697520627c58832f819b7fec1400b50d)