### PR TITLE
Add canonical packet schema validator for ChronometricVector

### DIFF
--- a/temporal_gradient/telemetry/chronometric_vector.py
+++ b/temporal_gradient/telemetry/chronometric_vector.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from typing import Optional
 import json
 
+from .schema import validate_packet_schema
+
 @dataclass
 class ChronometricVector:
     """
@@ -65,17 +67,7 @@ class ChronometricVector:
             legacy_keys = {"t_obj", "r", "legacy_density", "LEGACY_DENSITY", "clock_rate", "psi"}
             if legacy_keys.intersection(data.keys()):
                 raise ValueError("Legacy keys present in canonical packet.")
-            missing = {
-                "SCHEMA_VERSION",
-                "WALL_T",
-                "TAU",
-                "SALIENCE",
-                "CLOCK_RATE",
-                "MEMORY_S",
-                "DEPTH",
-            } - set(data.keys())
-            if missing:
-                raise ValueError(f"Missing required keys: {sorted(missing)}")
+            validate_packet_schema(data, salience_mode="canonical")
             return ChronometricVector(
                 wall_clock_time=data["WALL_T"],
                 tau=data["TAU"],

--- a/tests/test_chronometric_vector_schema.py
+++ b/tests/test_chronometric_vector_schema.py
@@ -53,6 +53,34 @@ def test_canonical_fixture_round_trip():
     assert round_trip.psi == pytest.approx(parsed.psi)
 
 
+def test_reject_out_of_range_salience_in_canonical_mode():
+    packet = {
+        "SCHEMA_VERSION": "1",
+        "WALL_T": 1.0,
+        "TAU": 0.9,
+        "SALIENCE": 1.5,
+        "CLOCK_RATE": 0.6667,
+        "MEMORY_S": 0.4,
+        "DEPTH": 0,
+    }
+    with pytest.raises(ValueError, match="SALIENCE"):
+        ChronometricVector.from_packet(json.dumps(packet), salience_mode="canonical")
+
+
+def test_reject_wrong_types_for_required_fields_in_canonical_mode():
+    packet = {
+        "SCHEMA_VERSION": "1",
+        "WALL_T": "1.0",
+        "TAU": 0.9,
+        "SALIENCE": 0.5,
+        "CLOCK_RATE": 0.6667,
+        "MEMORY_S": 0.4,
+        "DEPTH": "0",
+    }
+    with pytest.raises(TypeError):
+        ChronometricVector.from_packet(json.dumps(packet), salience_mode="canonical")
+
+
 def test_legacy_packet_requires_legacy_mode():
     legacy_packet = (FIXTURES / "legacy.jsonl").read_text().strip()
     with pytest.raises(ValueError):


### PR DESCRIPTION
### Motivation

- Ensure canonical telemetry packets are well-formed and fail fast on malformed input by validating required keys, types, and ranges before creating a `ChronometricVector`.
- Preserve existing legacy parsing behavior while providing stricter checks for the canonical packet format.

### Description

- Add `temporal_gradient/telemetry/schema.py` with `validate_packet_schema` that enforces required canonical keys (`SCHEMA_VERSION`, `WALL_T`, `TAU`, `SALIENCE`, `CLOCK_RATE`, `MEMORY_S`, `DEPTH`), numeric typing for numeric fields, `SALIENCE` range check in `[0.0, 1.0]`, `DEPTH` integer and non-negative checks, and optional `CLOCK_RATE` bounds validation.
- Wire the validator into `ChronometricVector.from_packet` by calling `validate_packet_schema(data, salience_mode="canonical")` prior to constructing the dataclass for canonical mode while leaving the `legacy_density` path unchanged.
- Extend `tests/test_chronometric_vector_schema.py` with tests that reject out-of-range `SALIENCE` and wrong types for required fields and keep the existing canonical-vs-legacy behavior tests.

### Testing

- Ran `pytest -q tests/test_chronometric_vector_schema.py` and all tests passed (`5 passed`).
- New tests added: `test_reject_out_of_range_salience_in_canonical_mode` and `test_reject_wrong_types_for_required_fields_in_canonical_mode`, which exercised the validator and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994d461dbc8832f87a5fa14d5c7c8d7)