### PR TITLE
Simplify v0.3 docs consistency checks and update packet contract targets

### DIFF
--- a/scripts/check_to_packet_contract.py
+++ b/scripts/check_to_packet_contract.py
@@ -13,7 +13,7 @@ TARGET_FILES: tuple[Path, ...] = (
     ROOT / "anomaly_poc.py",
     ROOT / "sanity_harness.py",
     ROOT / "simulation_run.py",
-    ROOT / "calibration_harness.py",
+    ROOT / "twin_paradox.py",
 )
 
 CONTRACT_MESSAGE = (

--- a/tests/test_docs_consistency_check.py
+++ b/tests/test_docs_consistency_check.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import scripts.check_docs_consistency as docs_check
+
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -17,3 +19,29 @@ def test_docs_consistency_check_passes():
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_check_doc_flags_deprecated_compute_budget_import(tmp_path: Path) -> None:
+    doc = tmp_path / "README.md"
+    doc.write_text(
+        "from temporal_gradient.policies.compute_budget import ComputeBudgetPolicy\n",
+        encoding="utf-8",
+    )
+
+    violations = docs_check.check_doc(doc)
+
+    assert any("deprecated policy shim path" in violation.message for violation in violations)
+
+
+def test_check_doc_requires_canonical_reference_for_canonical_guidance(tmp_path: Path) -> None:
+    doc = tmp_path / "USAGE.md"
+    doc.write_text("Canonical entry point guidance goes here.\n", encoding="utf-8")
+
+    original_refs = docs_check.EXPECTED_CANONICAL_REFS
+    docs_check.EXPECTED_CANONICAL_REFS = {doc: ("docs/CANONICAL_SURFACES.md",)}
+    try:
+        violations = docs_check.check_doc(doc)
+    finally:
+        docs_check.EXPECTED_CANONICAL_REFS = original_refs
+
+    assert any("docs/CANONICAL_SURFACES.md" in violation.message for violation in violations)

--- a/tests/test_packet_contract_check.py
+++ b/tests/test_packet_contract_check.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import scripts.check_to_packet_contract as packet_check
+
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -17,3 +19,14 @@ def test_packet_contract_check_passes() -> None:
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_packet_contract_targets_active_v03_entrypoints() -> None:
+    target_names = {path.name for path in packet_check.TARGET_FILES}
+
+    assert target_names == {
+        "anomaly_poc.py",
+        "sanity_harness.py",
+        "simulation_run.py",
+        "twin_paradox.py",
+    }


### PR DESCRIPTION
### Motivation
- Remove leftover shim-era policing and compatibility-marker logic that no longer applies now that migration shims have been removed. 
- Preserve canonical-reference enforcement to ensure docs point to the canonical surfaces document. 
- Align the runtime packet contract scanner with the active v0.3 entrypoints list.

### Description
- Simplified `scripts/check_docs_consistency.py` by removing shim-import detection, the compat-marker list, and surrounding compatibility-context checks, while keeping the canonical-reference checks and the `compute_budget` import guard; also tightened the reference-trigger regex and removed the README requirement for `docs/MIGRATION_SHIMS.md`.
- Updated `scripts/check_to_packet_contract.py` to scan the current v0.3 runtime entrypoints by replacing `calibration_harness.py` with `twin_paradox.py` in `TARGET_FILES`.
- Updated/added tests: `tests/test_docs_consistency_check.py` to validate the retained `compute_budget` guard and canonical-reference enforcement, and `tests/test_packet_contract_check.py` to assert the active v0.3 target set for the packet-contract scanner.

### Testing
- Ran the focused pytest suite with `pytest -q tests/test_docs_consistency_check.py tests/test_packet_contract_check.py` and all tests passed (`5 passed`).
- Executed `python scripts/check_docs_consistency.py` and it reported success for the docs set. 
- Executed `python scripts/check_to_packet_contract.py` and it reported success for the runtime packet contract check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a8f3bb450832fb3d9994293ccc0ff)