### PR TITLE
Preserve normalized schema version when serializing ChronometricVector

### DIFF
--- a/temporal_gradient/telemetry/chronometric_vector.py
+++ b/temporal_gradient/telemetry/chronometric_vector.py
@@ -36,7 +36,7 @@ class ChronometricVector:
 
     def to_packet(self) -> dict[str, Any]:
         packet = {
-            "SCHEMA_VERSION": CANONICAL_SCHEMA_VERSION,
+            "SCHEMA_VERSION": self.schema_version,
             "WALL_T": round(float(self.wall_clock_time), 2),
             "TAU": round(float(self.tau), 2),
             "SALIENCE": round(float(self.psi), 3),

--- a/tests/test_chronometric_vector_schema.py
+++ b/tests/test_chronometric_vector_schema.py
@@ -119,6 +119,35 @@ def test_legacy_packet_requires_legacy_mode():
     assert parsed.psi == pytest.approx(0.5)
 
 
+def test_legacy_mode_round_trip_preserves_normalized_schema_version():
+    legacy_packet = {
+        "SCHEMA_VERSION": "1",
+        "t_obj": 1.0,
+        "tau": 0.9,
+        "legacy_density": 0.5,
+        "r": 0,
+    }
+
+    parsed = ChronometricVector.from_packet(legacy_packet, salience_mode="legacy_density")
+    assert parsed.schema_version == "1.0"
+
+    round_trip_packet = parsed.to_packet()
+    assert round_trip_packet["SCHEMA_VERSION"] == parsed.schema_version == "1.0"
+
+
+def test_to_packet_defaults_to_canonical_schema_version_for_new_objects():
+    vector = ChronometricVector(
+        wall_clock_time=1.0,
+        tau=0.9,
+        psi=0.5,
+        recursion_depth=0,
+    )
+
+    packet = vector.to_packet()
+    assert vector.schema_version == "1.0"
+    assert packet["SCHEMA_VERSION"] == "1.0"
+
+
 def test_canonical_from_packet_strict_mode_requires_provenance_hash():
     packet = {
         "SCHEMA_VERSION": "1.0",


### PR DESCRIPTION
### Motivation
- Ensure `ChronometricVector.to_packet()` emits the instance's normalized schema version so legacy-schema inputs normalized in `__post_init__` round-trip correctly through `from_packet(..., salience_mode="legacy_density")` -> `to_packet()`.
- Maintain canonical behavior for newly created objects that do not supply legacy schema values.

### Description
- Change `ChronometricVector.to_packet()` to set `"SCHEMA_VERSION"` from `self.schema_version` instead of hardcoding `CANONICAL_SCHEMA_VERSION` in `temporal_gradient/telemetry/chronometric_vector.py`.
- Add `test_legacy_mode_round_trip_preserves_normalized_schema_version` to assert a legacy `"1"` value is normalized to `"1.0"` on `from_packet(..., salience_mode="legacy_density")` and that `to_packet()` emits the normalized value.
- Add `test_to_packet_defaults_to_canonical_schema_version_for_new_objects` to assert default-constructed vectors serialize with the canonical `"1.0"` schema version.

### Testing
- Ran `pytest -q tests/test_chronometric_vector_schema.py`, which succeeded with all tests passing (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a93a78d44832f900884cf20f1ec6c)