### PR TITLE
Add shared clock parameter validation for config and ClockRateModulator constructor

### DIFF
--- a/temporal_gradient/clock/validation.py
+++ b/temporal_gradient/clock/validation.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+def _raise(error_factory: Callable[[str], Exception], message: str) -> None:
+    raise error_factory(message)
+
+
+def coerce_clock_number(
+    value: Any,
+    key: str,
+    *,
+    error_factory: Callable[[str], Exception],
+    section_name: str = "clock",
+) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        _raise(error_factory, f"{section_name}.{key} must be numeric")
+    return float(value)
+
+
+def validate_clock_settings(
+    *,
+    base_dilation_factor: Any,
+    min_clock_rate: Any,
+    max_clock_rate: Any,
+    salience_mode: str,
+    legacy_density_scale: Any,
+    error_factory: Callable[[str], Exception],
+    section_name: str = "clock",
+) -> tuple[float, float, float, str, float]:
+    base_dilation = coerce_clock_number(
+        base_dilation_factor,
+        "base_dilation_factor",
+        error_factory=error_factory,
+        section_name=section_name,
+    )
+    min_rate = coerce_clock_number(
+        min_clock_rate,
+        "min_clock_rate",
+        error_factory=error_factory,
+        section_name=section_name,
+    )
+    max_rate = coerce_clock_number(
+        max_clock_rate,
+        "max_clock_rate",
+        error_factory=error_factory,
+        section_name=section_name,
+    )
+    density_scale = coerce_clock_number(
+        legacy_density_scale,
+        "legacy_density_scale",
+        error_factory=error_factory,
+        section_name=section_name,
+    )
+
+    if salience_mode not in {"canonical", "legacy_density"}:
+        _raise(error_factory, f"{section_name}.salience_mode must be 'canonical' or 'legacy_density'")
+
+    if base_dilation <= 0.0:
+        _raise(error_factory, f"{section_name}.base_dilation_factor must be > 0.0")
+    if min_rate <= 0.0:
+        _raise(error_factory, f"{section_name}.min_clock_rate must be > 0.0")
+    if min_rate > 1.0:
+        _raise(error_factory, f"{section_name}.min_clock_rate must be <= 1.0")
+    if max_rate <= 0.0:
+        _raise(error_factory, f"{section_name}.max_clock_rate must be > 0.0")
+    if max_rate > 1.0:
+        _raise(error_factory, f"{section_name}.max_clock_rate must be <= 1.0")
+    if min_rate > max_rate:
+        _raise(error_factory, f"{section_name}.min_clock_rate must be <= {section_name}.max_clock_rate")
+    if density_scale <= 0.0:
+        _raise(error_factory, f"{section_name}.legacy_density_scale must be > 0.0")
+
+    return base_dilation, min_rate, max_rate, salience_mode, density_scale

--- a/tests/test_clock_constructor_validation.py
+++ b/tests/test_clock_constructor_validation.py
@@ -1,0 +1,69 @@
+import textwrap
+
+import pytest
+
+from temporal_gradient.clock.chronos import ClockRateModulator
+from temporal_gradient.config_loader import ConfigValidationError, load_config
+
+
+def _write(tmp_path, body: str):
+    path = tmp_path / "tg.yaml"
+    path.write_text(textwrap.dedent(body))
+    return path
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_error",
+    [
+        ({"min_clock_rate": -0.1}, "clock.min_clock_rate must be > 0.0"),
+        ({"base_dilation_factor": 0.0}, "clock.base_dilation_factor must be > 0.0"),
+        ({"legacy_density_scale": 0.0}, "clock.legacy_density_scale must be > 0.0"),
+        (
+            {"min_clock_rate": 0.9, "max_clock_rate": 0.5},
+            "clock.min_clock_rate must be <= clock.max_clock_rate",
+        ),
+    ],
+)
+def test_direct_constructor_rejects_invalid_clock_bounds(kwargs, expected_error):
+    with pytest.raises(ValueError, match=expected_error):
+        ClockRateModulator(**kwargs)
+
+
+def test_constructor_error_matches_config_path_for_negative_min_clock_rate(tmp_path):
+    config_path = _write(
+        tmp_path,
+        """
+        salience: {}
+        clock:
+          min_clock_rate: -0.1
+        memory: {}
+        policies: {}
+        """,
+    )
+
+    with pytest.raises(ConfigValidationError) as config_exc:
+        load_config(config_path)
+    with pytest.raises(ValueError) as constructor_exc:
+        ClockRateModulator(min_clock_rate=-0.1)
+
+    assert str(constructor_exc.value) == str(config_exc.value)
+
+
+def test_constructor_error_matches_config_path_for_non_positive_base_dilation(tmp_path):
+    config_path = _write(
+        tmp_path,
+        """
+        salience: {}
+        clock:
+          base_dilation_factor: 0.0
+        memory: {}
+        policies: {}
+        """,
+    )
+
+    with pytest.raises(ConfigValidationError) as config_exc:
+        load_config(config_path)
+    with pytest.raises(ValueError) as constructor_exc:
+        ClockRateModulator(base_dilation_factor=0.0)
+
+    assert str(constructor_exc.value) == str(config_exc.value)


### PR DESCRIPTION
### Motivation
- Centralize numeric coercion and bounds checks for clock-related settings so the config loader and direct constructor enforce the same rules.
- Surface constructor-level validation for `ClockRateModulator` to fail-fast on invalid numeric inputs (e.g. negative `min_clock_rate`, non-positive `base_dilation_factor`, inverted min/max).

### Description
- Add a new validator module `temporal_gradient/clock/validation.py` exposing `validate_clock_settings()` and a helper `coerce_clock_number()` to perform numeric coercion and bounds checks for `base_dilation_factor`, `min_clock_rate`, `max_clock_rate`, `salience_mode`, and `legacy_density_scale`.
- Refactor `load_config()` in `temporal_gradient/config.py` to call `validate_clock_settings(..., error_factory=ConfigValidationError)` so config-path errors keep the same `ConfigValidationError` semantics.
- Update `ClockRateModulator.__init__` in `temporal_gradient/clock/chronos.py` to use `validate_clock_settings(..., error_factory=ValueError)` for constructor-level validation and add a `max_clock_rate` constructor argument; cap `clock_rate_from_psi()` output to be within `[min_clock_rate, max_clock_rate]`.
- Add tests in `tests/test_clock_constructor_validation.py` that assert invalid direct construction fails and that constructor error messages match the config-path `load_config()` errors.

### Testing
- Ran `pytest -q tests/test_clock_constructor_validation.py tests/test_clock_edge_cases.py tests/test_config_loader_strictness.py` which returned all tests passing (`33 passed`).
- Ran `pytest -q tests/test_clock_rate_modulator.py tests/test_config_loader.py` which also returned all tests passing (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a993ca548832fb7ebd5df203e2f95)