### PR TITLE
Refactor psi validation ownership in clock rate path

### DIFF
--- a/temporal_gradient/clock/chronos.py
+++ b/temporal_gradient/clock/chronos.py
@@ -68,6 +68,10 @@ class ClockRateModulator:
         strict mode rejects `psi > 1`, non-strict mode clamps it to `1.0`.
         """
         psi = self._validate_psi(psi)
+        return self._clock_rate_from_validated_psi(psi)
+
+    def _clock_rate_from_validated_psi(self, psi):
+        """Compute clock-rate from a psi value already canonicalized by `_validate_psi`."""
         scaled_psi = psi * self.base_dilation
         return min(self.max_clock_rate, max(self.min_clock_rate, 1 / (1 + scaled_psi)))
 
@@ -109,7 +113,7 @@ class ClockRateModulator:
                 raise ValueError("wall_delta must be non-negative")
             current_wall_time = self.last_tick + wall_delta
 
-        clock_rate = self.clock_rate_from_psi(psi)
+        clock_rate = self._clock_rate_from_validated_psi(psi)
         tau_delta = wall_delta * clock_rate
         self.tau += tau_delta
 


### PR DESCRIPTION
### Motivation
- Remove duplicated psi validation and make a single clear ownership point for canonicalization so public methods behave consistently.
- Keep the public API (`clock_rate_from_psi` and `tick`) semantics unchanged while making the internal rate computation non-validating for clarity and efficiency.

### Description
- Added a new internal helper `def _clock_rate_from_validated_psi(self, psi)` that computes the clock rate assuming `psi` is already canonicalized.
- Kept `clock_rate_from_psi()` as the public validating entry point that delegates to the new helper after calling `_validate_psi`.
- Updated `tick()` to perform psi canonicalization once via `_validate_psi` (or via legacy density conversion) and then call `_clock_rate_from_validated_psi` to compute the rate.
- Added a regression test `test_tick_validates_psi_once_before_internal_rate_calculation` in `tests/test_clock_edge_cases.py` to assert single validation and parity with the public rate method.

### Testing
- Ran `pytest -q tests/test_clock_edge_cases.py tests/test_clock_strict_mode.py` and all tests passed.
- Test suite result: `16 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a9c934340832f9923a21b51393f24)