### PR TITLE
Extract Chronos demo into standalone script entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ For complete canonical-vs-legacy mode behavior and lifecycle policy, see [`docs/
 See `CHANGELOG.md` for the full release history, including `v0.2.0` canonicalization and policy formalization details.
 
 
+
+## Chronos Demo
+Run:
+- `python scripts/chronos_demo.py`
+
+For fast smoke checks:
+- `python scripts/chronos_demo.py --sleep-seconds 0`
+
 ## Deterministic Embedding Replay Demo
 Run:
 - `python examples/embedding_novelty_replay_demo.py`

--- a/scripts/chronos_demo.py
+++ b/scripts/chronos_demo.py
@@ -1,0 +1,92 @@
+"""Chronos demo entrypoint.
+
+Usage:
+    python scripts/chronos_demo.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from temporal_gradient.clock.chronos import ClockRateModulator
+from temporal_gradient.salience.pipeline import KeywordImperativeValue, RollingJaccardNovelty, SaliencePipeline
+from temporal_gradient.telemetry.chronometric_vector import ChronometricVector
+
+
+def run_demo(*, sleep_seconds: float = 1.0) -> None:
+    agent_clock = ClockRateModulator()
+    salience = SaliencePipeline(RollingJaccardNovelty(), KeywordImperativeValue())
+
+    print(
+        f"{'EVENT':<20} | {'WALL_T':<8} | {'TAU':<10} | {'SALIENCE':<9} | "
+        f"{'CLOCK_RATE':<10} | {'MEMORY_S':<8} | {'DEPTH'}"
+    )
+    print("-" * 90)
+
+    simulated_events = [
+        "",
+        "Hello.",
+        "The quick brown fox jumps over the dog",
+        textwrap.dedent(
+            """
+            Time is a field gradient formed by memory + change.
+            Entropy’s arrow is not time itself, but an emergent
+            direction from memory accumulation.
+        """
+        )
+        * 5,
+    ]
+
+    start_time = time.time()
+    for event in simulated_events:
+        if sleep_seconds > 0:
+            time.sleep(sleep_seconds)
+
+        sal = salience.evaluate(event)
+        psi = sal.psi
+
+        agent_clock.tick(psi)
+        wall_time = time.time() - start_time
+
+        label = (event[:15] + "...") if len(event) > 15 else (event if event else "[EMPTY INPUT]")
+
+        packet_json = ChronometricVector(
+            wall_clock_time=wall_time,
+            tau=agent_clock.tau,
+            psi=psi,
+            recursion_depth=0,
+            clock_rate=agent_clock.clock_rate_from_psi(psi),
+            H=sal.novelty,
+            V=sal.value,
+            memory_strength=0.0,
+        ).to_packet_json()
+
+        print(
+            f"{label:<20} | {wall_time:<8.2f} | {agent_clock.tau:<10.4f} | {psi:<9.3f} | "
+            f"{agent_clock.clock_rate_from_psi(psi):<10.4f} | {0.0:<8.2f} | {0}"
+        )
+        print(f"{'PACKET':<8} | {packet_json}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the Chronos salience/clock demo.")
+    parser.add_argument(
+        "--sleep-seconds",
+        type=float,
+        default=1.0,
+        help="Seconds to sleep between events (default: 1.0). Use 0 for fast smoke tests.",
+    )
+    args = parser.parse_args()
+    run_demo(sleep_seconds=args.sleep_seconds)
+
+
+if __name__ == "__main__":
+    main()

--- a/temporal_gradient/clock/chronos.py
+++ b/temporal_gradient/clock/chronos.py
@@ -1,10 +1,7 @@
 import math
-import textwrap
 import time
 
 from temporal_gradient.clock.validation import validate_clock_settings
-from temporal_gradient.salience.pipeline import KeywordImperativeValue, RollingJaccardNovelty, SaliencePipeline
-from temporal_gradient.telemetry.chronometric_vector import ChronometricVector
 
 
 class ClockRateModulator:
@@ -131,56 +128,3 @@ class ClockRateModulator:
         self.last_tick = current_wall_time
         return tau_delta
 
-
-if __name__ == "__main__":
-    agent_clock = ClockRateModulator()
-    salience = SaliencePipeline(RollingJaccardNovelty(), KeywordImperativeValue())
-
-    print(
-        f"{'EVENT':<20} | {'WALL_T':<8} | {'TAU':<10} | {'SALIENCE':<9} | "
-        f"{'CLOCK_RATE':<10} | {'MEMORY_S':<8} | {'DEPTH'}"
-    )
-    print("-" * 90)
-
-    simulated_events = [
-        "",
-        "Hello.",
-        "The quick brown fox jumps over the dog",
-        textwrap.dedent(
-            """
-            Time is a field gradient formed by memory + change.
-            Entropy’s arrow is not time itself, but an emergent
-            direction from memory accumulation.
-        """
-        )
-        * 5,
-    ]
-
-    start_time = time.time()
-    for event in simulated_events:
-        time.sleep(1.0)
-
-        sal = salience.evaluate(event)
-        psi = sal.psi
-
-        agent_clock.tick(psi)
-        wall_time = time.time() - start_time
-
-        label = (event[:15] + "...") if len(event) > 15 else (event if event else "[EMPTY INPUT]")
-
-        packet_json = ChronometricVector(
-            wall_clock_time=wall_time,
-            tau=agent_clock.tau,
-            psi=psi,
-            recursion_depth=0,
-            clock_rate=agent_clock.clock_rate_from_psi(psi),
-            H=sal.novelty,
-            V=sal.value,
-            memory_strength=0.0,
-        ).to_packet_json()
-
-        print(
-            f"{label:<20} | {wall_time:<8.2f} | {agent_clock.tau:<10.4f} | {psi:<9.3f} | "
-            f"{agent_clock.clock_rate_from_psi(psi):<10.4f} | {0.0:<8.2f} | {0}"
-        )
-        print(f"{'PACKET':<8} | {packet_json}")

--- a/tests/test_chronos_demo.py
+++ b/tests/test_chronos_demo.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_chronos_demo_smoke_output_sections() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/chronos_demo.py", "--sleep-seconds", "0"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "EVENT" in result.stdout
+    assert "CLOCK_RATE" in result.stdout
+    assert "PACKET" in result.stdout
+    assert "[EMPTY INPUT]" in result.stdout


### PR DESCRIPTION
### Motivation
- Keep `temporal_gradient/clock/chronos.py` focused on library/runtime classes by removing an embedded demo `if __name__ == "__main__"` block. 
- Provide an explicit, testable CLI entrypoint for the demo so docs and CI can run a fast smoke check. 

### Description
- Removed the demo-only imports and `if __name__ == "__main__"` execution block from `temporal_gradient/clock/chronos.py` to keep it a pure library surface. 
- Added a dedicated demo script at `scripts/chronos_demo.py` containing `run_demo(...)` and a `main()` with a `--sleep-seconds` CLI flag for fast smoke runs. 
- Updated `README.md` to document running the demo via `python scripts/chronos_demo.py` and the fast-check variant `python scripts/chronos_demo.py --sleep-seconds 0`. 
- Added a lightweight smoke test `tests/test_chronos_demo.py` that executes the new script and asserts expected output sections (`EVENT`, `CLOCK_RATE`, `PACKET`, `[EMPTY INPUT]`). 

### Testing
- Ran `pytest -q tests/test_chronos_demo.py tests/test_clock_rate_modulator.py` and the test suite passed (`3 passed`). 
- Ran documentation guard `python scripts/check_docs_consistency.py` and it passed (no missing canonical references).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa83d1c2c832fb3c81f9227a26ba4)