### PR TITLE
Add shared legacy compatibility policy and refactor clock/telemetry to use it

### DIFF
--- a/temporal_gradient/clock/validation.py
+++ b/temporal_gradient/clock/validation.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from temporal_gradient.compat.legacy import SALIENCE_MODES
+
 
 def _raise(error_factory: Callable[[str], Exception], message: str) -> None:
     raise error_factory(message)
@@ -54,7 +56,7 @@ def validate_clock_settings(
         section_name=section_name,
     )
 
-    if salience_mode not in {"canonical", "legacy_density"}:
+    if salience_mode not in SALIENCE_MODES:
         _raise(error_factory, f"{section_name}.salience_mode must be 'canonical' or 'legacy_density'")
 
     if base_dilation <= 0.0:

--- a/temporal_gradient/compat/__init__.py
+++ b/temporal_gradient/compat/__init__.py
@@ -1,0 +1,23 @@
+"""Compatibility helpers shared across temporal-gradient modules."""
+
+from .legacy import (
+    CANONICAL_MODE,
+    LEGACY_DENSITY_MODE,
+    LEGACY_PACKET_FALLBACK_KEYS,
+    LEGACY_REJECTED_CANONICAL_KEYS,
+    SALIENCE_MODES,
+    coerce_legacy_schema_version,
+    legacy_packet_value,
+    normalize_legacy_density_to_psi,
+)
+
+__all__ = [
+    "CANONICAL_MODE",
+    "LEGACY_DENSITY_MODE",
+    "LEGACY_PACKET_FALLBACK_KEYS",
+    "LEGACY_REJECTED_CANONICAL_KEYS",
+    "SALIENCE_MODES",
+    "coerce_legacy_schema_version",
+    "legacy_packet_value",
+    "normalize_legacy_density_to_psi",
+]

--- a/temporal_gradient/compat/legacy.py
+++ b/temporal_gradient/compat/legacy.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping, Sequence
+
+CANONICAL_MODE = "canonical"
+LEGACY_DENSITY_MODE = "legacy_density"
+SALIENCE_MODES = {CANONICAL_MODE, LEGACY_DENSITY_MODE}
+
+LEGACY_REJECTED_CANONICAL_KEYS = {
+    "t_obj",
+    "r",
+    "legacy_density",
+    "LEGACY_DENSITY",
+    "clock_rate",
+    "psi",
+}
+
+LEGACY_PACKET_FALLBACK_KEYS: dict[str, tuple[str, ...]] = {
+    "wall_clock_time": ("WALL_T", "t_obj"),
+    "tau": ("TAU", "tau"),
+    "psi": ("SALIENCE", "psi", "legacy_density", "LEGACY_DENSITY"),
+    "recursion_depth": ("DEPTH", "r"),
+    "clock_rate": ("CLOCK_RATE", "clock_rate"),
+    "memory_strength": ("MEMORY_S", "S"),
+}
+
+
+def legacy_packet_value(data: Mapping[str, Any], key_path: Sequence[str]) -> Any:
+    for key in key_path:
+        if key in data:
+            return data[key]
+    return None
+
+
+def normalize_legacy_density_to_psi(density: Any, legacy_density_scale: float) -> float | None:
+    if density is None:
+        return None
+    scaled = float(density) / float(legacy_density_scale)
+    return max(0.0, min(1.0, scaled))
+
+
+def coerce_legacy_schema_version(
+    value: Any,
+    *,
+    canonical_schema_version: str,
+    normalizer: Callable[[str], str],
+) -> str:
+    if not isinstance(value, str):
+        return canonical_schema_version
+    try:
+        return normalizer(value)
+    except ValueError:
+        return canonical_schema_version

--- a/tests/test_legacy_compat_integration.py
+++ b/tests/test_legacy_compat_integration.py
@@ -1,0 +1,59 @@
+import pytest
+
+from temporal_gradient.clock.chronos import ClockRateModulator
+from temporal_gradient.compat.legacy import normalize_legacy_density_to_psi
+from temporal_gradient.telemetry.chronometric_vector import ChronometricVector
+
+
+def test_clock_legacy_density_input_context_matches_normalized_density_policy():
+    clock = ClockRateModulator(salience_mode="legacy_density", legacy_density_scale=10.0)
+
+    tau_delta = clock.tick(input_context="aaaaab", wall_delta=2.0)
+
+    expected_density = clock.calculate_information_density("aaaaab")
+    expected_psi = normalize_legacy_density_to_psi(expected_density, 10.0)
+    expected_rate = clock.clock_rate_from_psi(expected_psi)
+
+    assert tau_delta == pytest.approx(2.0 * expected_rate)
+    assert clock.chronology[-1]["psi"] == pytest.approx(round(expected_psi, 4))
+    assert clock.chronology[-1]["diagnostic_density"] == pytest.approx(round(expected_density, 2))
+
+
+def test_telemetry_legacy_packet_fallbacks_still_parse_with_legacy_mode():
+    legacy_packet = {
+        "SCHEMA_VERSION": "1",
+        "t_obj": 10.0,
+        "tau": 3.5,
+        "LEGACY_DENSITY": 0.42,
+        "r": 2,
+        "clock_rate": 0.7,
+        "S": 0.25,
+    }
+
+    parsed = ChronometricVector.from_packet(legacy_packet, salience_mode="legacy_density")
+
+    assert parsed.wall_clock_time == pytest.approx(10.0)
+    assert parsed.tau == pytest.approx(3.5)
+    assert parsed.psi == pytest.approx(0.42)
+    assert parsed.recursion_depth == 2
+    assert parsed.clock_rate == pytest.approx(0.7)
+    assert parsed.memory_strength == pytest.approx(0.25)
+    assert parsed.schema_version == "1.0"
+
+
+def test_legacy_telemetry_salience_drives_same_clock_rate_as_canonical_path():
+    legacy_packet = {
+        "t_obj": 5.0,
+        "tau": 1.0,
+        "legacy_density": 0.3,
+        "r": 1,
+    }
+    parsed = ChronometricVector.from_packet(legacy_packet, salience_mode="legacy_density")
+
+    legacy_clock = ClockRateModulator(salience_mode="legacy_density")
+    canonical_clock = ClockRateModulator(salience_mode="canonical")
+
+    legacy_delta = legacy_clock.tick(psi=parsed.psi, wall_delta=1.0)
+    canonical_delta = canonical_clock.tick(psi=parsed.psi, wall_delta=1.0)
+
+    assert legacy_delta == pytest.approx(canonical_delta)


### PR DESCRIPTION
### Motivation
- Centralize legacy compatibility policy to avoid duplicated compatibility branches and reduce drift between clock and telemetry parsing logic.
- Provide a small set of helpers and constants to normalize legacy density values, coerce legacy schema versions, and define canonical/legacy key fallbacks so both clock and telemetry can share the same policy.

### Description
- Add a new compatibility module at `temporal_gradient/compat/legacy.py` that defines `CANONICAL_MODE`, `LEGACY_DENSITY_MODE`, `SALIENCE_MODES`, `LEGACY_REJECTED_CANONICAL_KEYS`, `LEGACY_PACKET_FALLBACK_KEYS`, `legacy_packet_value`, `normalize_legacy_density_to_psi`, and `coerce_legacy_schema_version`, and re-export these from `temporal_gradient/compat/__init__.py`.
- Refactor `ClockRateModulator` in `temporal_gradient/clock/chronos.py` to use `CANONICAL_MODE`/`LEGACY_DENSITY_MODE` and `normalize_legacy_density_to_psi` instead of embedded legacy logic, and update validation in `temporal_gradient/clock/validation.py` to use `SALIENCE_MODES`.
- Refactor telemetry parsing in `temporal_gradient/telemetry/chronometric_vector.py` to reject legacy keys in canonical mode using `LEGACY_REJECTED_CANONICAL_KEYS`, to read fallback values via `LEGACY_PACKET_FALLBACK_KEYS` and `legacy_packet_value`, and to coerce legacy schema versions via `coerce_legacy_schema_version`.
- Add integration tests in `tests/test_legacy_compat_integration.py` that exercise legacy-density normalization through `ClockRateModulator.tick`, legacy telemetry packet fallbacks, and parity between legacy-derived salience and canonical clock-rate behavior.

### Testing
- Ran targeted tests with `pytest -q tests/test_legacy_compat_integration.py tests/test_chronometric_vector_schema.py tests/test_clock_edge_cases.py` and all tests passed with `27 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa956b704832faecd1400ede6319a)