### PR TITLE
docs: align internal timebase equation with chronos parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,17 @@ All claims are limited to defined state variables, dynamics, and testable invari
 
 ### Internal timebase
 \[
-\frac{d\tau}{dt}=\frac{1}{1+\Psi(t)}, \quad \Psi(t)=H(x_t)\cdot V(x_t)
+\frac{d\tau}{dt}=\frac{1}{1+\texttt{base\_dilation\_factor}\cdot\Psi(t)}, \quad \Psi(t)=H(x_t)\cdot V(x_t)
 \]
+
+In code, this is implemented by `ClockRateModulator._clock_rate_from_validated_psi(...)` as:
+`clock_rate = 1 / (1 + psi * base_dilation)` with min/max clamping.
+To map docs to constructor names in `temporal_gradient/clock/chronos.py`:
+- `base_dilation_factor` (constructor arg) is validated and stored as `self.base_dilation`.
+- `psi` is the salience load input used by `clock_rate_from_psi(psi)` and `tick(psi=...)`.
+- `min_clock_rate` and `max_clock_rate` bound the final clock rate.
+
+Default factor assumption: `base_dilation_factor=1.0`.
 
 ### Entropic memory decay
 \[


### PR DESCRIPTION
### Motivation
- Clarify the README's internal timebase equation so it matches the implemented form and make it easy for readers to map documentation terms to the code in `temporal_gradient/clock/chronos.py`.

### Description
- Update the internal timebase equation to `dτ/dt = 1 / (1 + base_dilation_factor * Ψ(t))`, add an explicit note that the implementation lives in `ClockRateModulator._clock_rate_from_validated_psi(...)`, map documentation names to constructor/instance names (`base_dilation_factor` → `self.base_dilation`, `psi`, `min_clock_rate`, `max_clock_rate`), and state the default factor `base_dilation_factor=1.0`.

### Testing
- Ran `python scripts/check_docs_consistency.py` and the documentation consistency check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aafc02130832facdc1184cf0de90c)