### PR TITLE
Clarify canonical output policy and legacy input normalization

### DIFF
--- a/docs/CANONICAL_VS_LEGACY.md
+++ b/docs/CANONICAL_VS_LEGACY.md
@@ -4,6 +4,8 @@ This document is the single lifecycle authority for canonical vs legacy runtime 
 
 ## Mode Definitions
 
+Policy baseline: canonical format is required for all outputs and current interfaces. During migration, specific legacy input forms may still be accepted at ingress and are normalized internally to canonical values.
+
 ### `canonical`
 
 Use `canonical` mode for all new code and integrations.
@@ -11,6 +13,7 @@ Use `canonical` mode for all new code and integrations.
 - Enforces canonical telemetry schema validation with required canonical packet keys.
 - Treats normalized salience values as authoritative (`psi` from canonical salience pipeline outputs).
 - Rejects packet payloads that do not conform to canonical schema expectations.
+- Requires canonical output serialization for current interfaces (for example, `SCHEMA_VERSION: "1.0"`).
 
 ### `legacy_density`
 
@@ -19,6 +22,14 @@ Use `canonical` mode for all new code and integrations.
 - Preserves support for legacy packet shapes during migration windows.
 - Derives and clamps salience from entropy density when canonical salience inputs are absent.
 - Applies compatibility-oriented validation behavior rather than strict canonical enforcement.
+- Accepts only documented legacy input forms at boundaries and normalizes them to canonical internal values.
+
+### Accepted legacy inputs
+
+The following legacy forms are accepted for migration input only; runtime state and outputs remain canonical.
+
+- `SCHEMA_VERSION: "1"` → normalized to `SCHEMA_VERSION: "1.0"`.
+- Mixed key packets that include canonical required keys plus legacy-compatible shape in `legacy_density` mode → normalized and processed against canonical internal fields before downstream use.
 
 ## Behavior Deltas (`canonical` vs `legacy_density`)
 

--- a/temporal_gradient/telemetry/schema.py
+++ b/temporal_gradient/telemetry/schema.py
@@ -1,4 +1,9 @@
-"""Telemetry packet schema validation for canonical v0.2.0 packets."""
+"""Telemetry packet schema validation for canonical v0.2.0 packets.
+
+Policy: canonical format is required for outputs/current interfaces. Specific
+legacy input forms are accepted only for migration at ingress and normalized
+internally to canonical values.
+"""
 
 import math
 from numbers import Real
@@ -38,8 +43,9 @@ def _is_finite_numeric(value: Any) -> bool:
 def normalize_schema_version(schema_version: str) -> str:
     """Normalize schema version values to the canonical version string.
 
-    Canonical packets must serialize as ``"1.0"``. Legacy packets that still
-    carry ``"1"`` are accepted for migration and normalized to ``"1.0"``.
+    Canonical ``SCHEMA_VERSION`` for outputs/current interfaces is ``"1.0"``.
+    Legacy migration input ``"1"`` is accepted and normalized internally to
+    ``"1.0"``.
     """
     if schema_version == CANONICAL_SCHEMA_VERSION:
         return CANONICAL_SCHEMA_VERSION
@@ -59,7 +65,12 @@ def validate_packet_schema(
     clock_rate_bounds: Optional[Tuple[float, float]] = None,
     require_provenance_hash: bool = False,
 ) -> None:
-    """Validate canonical telemetry packets with explicit typing (no coercion)."""
+    """Validate canonical telemetry packets with explicit typing (no coercion).
+
+    Canonical format is required for current interfaces. Validation still
+    accepts documented legacy migration inputs (for example,
+    ``SCHEMA_VERSION == "1"``) and normalizes them internally.
+    """
     if salience_mode != "canonical":
         return
 


### PR DESCRIPTION
### Motivation
- Make the policy explicit that canonical format is the required form for outputs/current interfaces while still allowing documented legacy input forms at ingress for migration and internal normalization. 
- Keep user-facing documentation and in-code validation messaging aligned so implementers and integrators see the same policy language.

### Description
- Updated `docs/CANONICAL_VS_LEGACY.md` to add a policy baseline statement and a new "Accepted legacy inputs" subsection with concrete examples including `SCHEMA_VERSION: "1"` → normalized to `SCHEMA_VERSION: "1.0"`.
- Added clarifying bullet to the `canonical` and `legacy_density` mode descriptions explaining canonical output serialization is required and that only documented legacy inputs are accepted at boundaries and normalized internally.
- Aligned `temporal_gradient/telemetry/schema.py` module and function docstrings (`normalize_schema_version` and `validate_packet_schema`) to mirror the same policy language about canonical outputs and legacy input normalization, with no behavioral changes to validation logic.

### Testing
- Ran `python -m compileall temporal_gradient/telemetry/schema.py docs/CANONICAL_VS_LEGACY.md` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ab0cf59b8832f835f20c91df9010f)