### PR TITLE
docs: fix telemetry schema docs and stale chronolog onboarding template

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Canonical telemetry is validated against the required schema keys and should be 
 - `to_packet_json()` => returns a JSON `str` for transport, storage, or logging contexts.
 - Do not call `json.loads(to_packet())`; `to_packet()` is already the structured mapping.
 
+- `SCHEMA_VERSION`
 - `WALL_T`
 - `TAU`
 - `SALIENCE`
@@ -134,7 +135,7 @@ Canonical telemetry is validated against the required schema keys and should be 
 - `DEPTH`
 
 `validate_packet_schema(...)` is the canonical validator; `validate_packet(...)` remains a compatibility alias.
-`ChronometricVector.to_packet()` returns the canonical packet mapping (`dict`); use `to_packet_json()` only when serialized JSON text is explicitly required.
+`ChronometricVector.to_packet()` returns the canonical packet mapping (`dict`) and emits canonical `SCHEMA_VERSION` (`"1.0"`); use `to_packet_json()` only when serialized JSON text is explicitly required.
 
 For complete canonical-vs-legacy mode behavior and lifecycle policy, see [`docs/CANONICAL_VS_LEGACY.md`](docs/CANONICAL_VS_LEGACY.md).
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -69,6 +69,27 @@ Legacy compatibility packet (allowed only in `legacy_density` mode):
 
 See `docs/CANONICAL_VS_LEGACY.md` for the full migration guidance and deprecation horizon.
 
+## Minimal packet round-trip example (canonical)
+
+```python
+import temporal_gradient as tg
+from temporal_gradient.telemetry.schema import validate_packet_schema
+
+packet = tg.telemetry.ChronometricVector(
+    wall_clock_time=1.0,
+    tau=0.5,
+    psi=0.4,
+    recursion_depth=0,
+    clock_rate=0.71,
+    memory_strength=0.2,
+).to_packet()
+
+validate_packet_schema(packet, salience_mode="canonical")
+print(packet["SCHEMA_VERSION"], packet["SALIENCE"])
+```
+
+This prints canonical packet fields (`SCHEMA_VERSION` and `SALIENCE`) from the in-memory `dict` returned by `to_packet()`.
+
 
 ## 1. The clock-rate table
 This table shows how the internal clock-rate is reparameterized by salience load (surprise × value).

--- a/docs/DAY1_CONTRIBUTOR_MAP.md
+++ b/docs/DAY1_CONTRIBUTOR_MAP.md
@@ -59,13 +59,12 @@ Read [`docs/CANONICAL_VS_LEGACY.md`](./CANONICAL_VS_LEGACY.md) before touching m
 
 Use these starter templates for small, high-signal first contributions.
 
-### Template A — TG-TASK-001 (`chronolog` → `chronology`)
-- **Goal:** Make `clock.chronology` the preferred attribute while preserving `chronolog` as a temporary alias.
-- **Likely files:** `temporal_gradient/clock/chronos.py`, relevant docs/tests discovered during search.
+### Template A — TG-TASK-001 (`chronolog` cleanup verification)
+- **Goal:** Remove remaining references to removed `chronolog` alias and keep `clock.chronology` as the only supported attribute.
+- **Likely files:** docs/tests referencing clock telemetry history names.
 - **Checklist:**
-  - [x] Add/confirm canonical attribute and compatibility alias.
-  - [x] Add a deprecation note for alias usage.
-  - [x] Update docs/tests to prefer `chronology`.
+  - [x] Replace `chronolog` references with `chronology`.
+  - [x] Confirm no code path relies on `chronolog`.
   - [x] Run clock + API/docs tests listed above.
 
 ### Template B — TG-TASK-002 (anomaly PoC key alignment)


### PR DESCRIPTION
### Motivation
- The docs claimed a canonical packet shape but omitted the required `SCHEMA_VERSION` key and did not state that `ChronometricVector.to_packet()` emits the canonical schema version; this mismatched the actual serializer and schema validator behavior.
- A Day‑1 contributor template still described preserving a removed `chronolog` alias, which is outdated and could mislead contributors.
- A short, copy/paste usage example for the canonical packet round‑trip was missing and would help reduce confusion when using `to_packet()` + `validate_packet_schema()`.

### Description
- Updated `README.md` telemetry section to include `SCHEMA_VERSION` in the canonical key list and clarified that `ChronometricVector.to_packet()` emits `SCHEMA_VERSION: "1.0"` in the returned `dict` mapping.
- Added a minimal, executable canonical packet round‑trip example to `USAGE.md` demonstrating `ChronometricVector(...).to_packet()` plus `validate_packet_schema(...)` and reading `SCHEMA_VERSION`/`SALIENCE` from the returned mapping.
- Rewrote the Day‑1 contributor template in `docs/DAY1_CONTRIBUTOR_MAP.md` to remove guidance about preserving the removed `chronolog` alias and instead instruct contributors to verify alias cleanup and use `clock.chronology` only.

### Testing
- Ran `python -m pytest -q tests/test_readme_minimal_canonical_usage_flow.py tests/test_docs_consistency_check.py` and both tests passed (`4 passed`).
- Ran `python scripts/check_docs_consistency.py` and the documentation consistency check succeeded (passed for 3 files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad3c2fa78832fbb9b7f1e55d84864)