### PR TITLE
Label chronos_engine shim as compatibility-only to satisfy canonical refs check

### DIFF
--- a/docs/CODE_REVIEW_AUDIT.md
+++ b/docs/CODE_REVIEW_AUDIT.md
@@ -141,7 +141,7 @@ This instantiates and immediately discards a frozen dataclass on every call. For
 ## 3. Deprecation Status
 
 ### DEP-01 — Root-level shim files: no hard removal date bound
-**Files:** `chronos_engine.py`, `salience_pipeline.py`, `entropic_decay.py`, `chronometric_vector.py`
+**Files:** `chronos_engine.py` (compatibility-only shim), `salience_pipeline.py`, `entropic_decay.py`, `chronometric_vector.py`
 
 CHANGELOG states shims are "retained for one release window" since v0.2.0. `CANONICAL_VS_LEGACY.md` targets v0.4.0+ for removal, with v0.3.x as "staged removal by subsystem." However, no specific shim is targeted for removal in the `V0.3.0_PR_CHECKLIST.md`. The timeline is described but not enforced.
 


### PR DESCRIPTION
### Motivation
- Fix a CI failure where `scripts/check_canonical_refs.py` rejects mentions of `chronos_engine.py` that are not explicitly marked as compatibility-only, by updating the docs to reflect the shim status.

### Description
- Update `docs/CODE_REVIEW_AUDIT.md` to change the DEP-01 file list entry to `chronos_engine.py (compatibility-only shim)` so it matches the canonicalization rule.

### Testing
- Ran `python scripts/check_canonical_refs.py` and `pytest -q` locally; the canonical check passed and the full test suite completed with `184 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a0b03234832fac892c0591499762)