### PR TITLE
Clarify compatibility-only status for root shim files in audit docs

### DIFF
--- a/docs/CODE_REVIEW_AUDIT.md
+++ b/docs/CODE_REVIEW_AUDIT.md
@@ -141,7 +141,7 @@ This instantiates and immediately discards a frozen dataclass on every call. For
 ## 3. Deprecation Status
 
 ### DEP-01 — Root-level shim files: no hard removal date bound
-**Files:** `chronos_engine.py` (compatibility-only shim), `salience_pipeline.py`, `entropic_decay.py`, `chronometric_vector.py`
+**Files:** `chronos_engine.py` (compatibility-only shim), `salience_pipeline.py` (compatibility-only shim), `entropic_decay.py` (compatibility-only shim), `chronometric_vector.py` (compatibility-only shim)
 
 CHANGELOG states shims are "retained for one release window" since v0.2.0. `CANONICAL_VS_LEGACY.md` targets v0.4.0+ for removal, with v0.3.x as "staged removal by subsystem." However, no specific shim is targeted for removal in the `V0.3.0_PR_CHECKLIST.md`. The timeline is described but not enforced.
 


### PR DESCRIPTION
### Motivation

- The documentation audit wording for root-level shim files was ambiguous and could trigger the canonicalization checker which expects explicit compatibility wording when shims are referenced.

### Description

- Update `docs/CODE_REVIEW_AUDIT.md` to explicitly label the root shim files `chronos_engine.py`, `salience_pipeline.py`, `entropic_decay.py`, and `chronometric_vector.py` as "compatibility-only shim" to align wording with the canonical refs checker.

### Testing

- Ran `python scripts/check_canonical_refs.py` and it passed without errors.
- Ran `pytest -q` and all tests passed (`184 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a4da46d8832fa07d1bada79522e0)