### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/WhatsYourWhy/The-Temporal-Gradient/security/code-scanning/1](https://github.com/WhatsYourWhy/The-Temporal-Gradient/security/code-scanning/1)

In general, the fix is to explicitly declare a minimal `permissions` block for the workflow or for the specific job, instead of relying on repository or organization defaults. For this workflow, the steps only read repository contents and run tests/scripts, so they only need read access to `contents`.

The best minimal fix without changing existing functionality is to add a `permissions` block at the workflow root level (so it applies to all jobs) setting `contents: read`. This documents the intended permissions and ensures the `GITHUB_TOKEN` used by the workflow cannot perform write operations unless explicitly granted in the future.

Concretely, in `.github/workflows/pytest.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` section and the `jobs:` section. No imports or additional methods are needed; it is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
