### PR TITLE
Release v0.3.0: MIT license, version bump, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,105 +1,110 @@
 # Changelog
 
-## Unreleased
+## v0.3.0 — Cleanup & simplification
 
-Keep canonical-vs-legacy release messaging aligned with [`docs/CANONICAL_VS_LEGACY.md`](docs/CANONICAL_VS_LEGACY.md) when adding entries below.
+**Release focus:** remove accumulated compatibility cruft, consolidate
+the repo layout, and restate the public API as a single code path.
 
+### Removed
 
-### Compatibility shims and legacy mode updates (template)
-
-> Copy this block into each release section and fill it in to keep migration messaging consistent.
-
-- Canonical status this release: `[default/required/unchanged]`
-- Legacy mode status (`legacy_density`): `[supported/deprecated/removed]`
-- Root-level compatibility shims: `[unchanged/expanded/reduced]`
-- Migration guidance updates: `[link to docs/CANONICAL_VS_LEGACY.md changes]`
-- Planned removal horizon: `v0.3.x staged removal by subsystem (not full shim removal in a single release)`
+- Root-level compatibility shims (`chronos_engine.py`,
+  `chronometric_vector.py`, `entropic_decay.py`, `salience_pipeline.py`).
+- `codex_valuation.py` and its `CodexNoveltyAdapter` /
+  `CodexValueAdapter` bridges in `temporal_gradient.salience.pipeline`.
+- `temporal_gradient/compat/` — legacy schema-version coercion, packet
+  fallback keys, density-to-psi normalization.
+- `legacy_density` salience mode:
+  `ClockRateModulator(salience_mode=..., legacy_density_scale=...)`,
+  the `input_context` tick argument, and
+  `calculate_information_density()` / `_psi_from_legacy_density()`.
+- `validate_packet_schema(salience_mode=...)` kwarg and the
+  `validate_packet()` compatibility alias — use `validate_packet_schema()`.
+- `ChronometricVector.from_packet(salience_mode=...)` and its legacy
+  branch that read `t_obj` / `r` / `legacy_density` keys.
+- Legacy `"1"` schema-version migration — only `"1.0"` is accepted.
+- `anomaly_detection.py` `memories_alive` / `memories_forgotten` result
+  aliases — use `total_swept_survivors` / `total_swept_forgotten`.
+- Process / planning docs that had leaked into the public tree
+  (`V0.2.0_PR_CHECKLIST.md`, `V0.3.0_PR_CHECKLIST.md`,
+  `TASK_PROPOSALS.md`, `docs_knob_validation_checklist.md`,
+  `docs/CODE_REVIEW_AUDIT.md`, `docs/DOC_CHANGE_CHECKLIST.md`,
+  `docs/DAY1_CONTRIBUTOR_MAP.md`, `docs/MIGRATION_SHIMS.md`,
+  `docs/NEWCOMER_GUIDE.md`, `docs/CANONICAL_VS_LEGACY.md`,
+  `docs/CANONICAL_SURFACES.md`, `docs/archive/`).
+- Meta-tests that guarded shim / doc surface rather than behavior.
 
 ### Changed
 
-- Removed `ClockRateModulator.chronolog` typo alias; use `ClockRateModulator.chronology` for clock telemetry history reads/writes.
+- Runnable entrypoints moved out of the repo root into `examples/`:
+  `anomaly_poc.py` → `examples/anomaly_detection.py`,
+  `simulation_run.py` → `examples/simulation.py`, and
+  `twin_paradox.py`, `sanity_harness.py`, `calibration_harness.py`.
+- Each example prepends the repo root to `sys.path` so it runs from a
+  clean checkout without `pip install`.
+- `GLOSSARY.md`, `SAFETY.md`, `USAGE.md` moved into `docs/` (lowercase).
+- README rewritten: leads with what the framework does, install, and a
+  minimal usage example; architecture and schema details moved to
+  `docs/architecture.md`.
+- License changed from a bespoke source-available "no execute" clause
+  to the standard **MIT License**.
 
-### Documentation
+### Added
 
-- Reviewed executable/documentation alignment and re-ran the project validation suite (`pytest -q`), with all tests passing.
-- Clarified and guarded packet contract expectations so canonical packet shape requirements are explicit in release notes and docs.
-- Aligned runtime path messaging with canonical module usage to reduce ambiguity between shim and canonical import flows.
-- Added regression-protection callouts tied to test and docs consistency checks to keep behavior and documentation in lockstep.
-- Archived completed validation documents under `docs/archive/`:
-  - `AUDIT_REPORT.md` → `docs/archive/AUDIT_REPORT.md`
-  - `poc_validation_report.md` → `docs/archive/poc_validation_report.md`
-- Updated `README.md` to document the archive location and latest validation-run status.
+- `pyproject.toml` (Python ≥3.10, optional `PyYAML`, `[dev]` extra
+  installs `pytest`).
+- `docs/architecture.md` — layer map, data-flow diagram, telemetry
+  schema reference.
+
+### Migration
+
+- Replace `from temporal_gradient.telemetry.schema import validate_packet`
+  with `validate_packet_schema`.
+- Drop `salience_mode=` / `legacy_density_scale=` kwargs from
+  `ClockRateModulator(...)` — there is one code path now.
+- Drop `salience_mode=` from `validate_packet_schema(...)` and
+  `ChronometricVector.from_packet(...)`.
+- Drop `input_context=` from `clock.tick(...)`; pass `psi=` directly.
+- Replace root-level script paths (`python anomaly_poc.py`, etc.) with
+  the new `examples/` locations.
+- Consumers of `run_poc(...)`'s result dict should read
+  `total_swept_survivors` / `total_swept_forgotten` instead of
+  `memories_alive` / `memories_forgotten`.
 
 ## v0.2.0 — Canonicalization & Policy Layer Formalization
 
 **Release focus:**
-Stabilize the public API surface, normalize naming, formalize the policy layer, and enforce telemetry/schema discipline.
+Stabilize the public API surface, normalize naming, formalize the policy
+layer, and enforce telemetry/schema discipline.
 
 ### Added
 
-- Canonical config surface:
-  - `temporal_gradient.config_loader`
-  - `load_config(...)` exposed at package root
-- Telemetry schema validator:
-  - `validate_packet_schema(...)` (canonical)
-  - `validate_packet(...)` retained as compatibility alias
-- Policy layer:
-  - `ComputeCooldownPolicy` (canonical)
-  - `allows_compute(...)` cooldown gate
-- Structured subsystem test files for:
-  - config loader
-  - clock invariants
-  - telemetry schema
-  - policies
-- Compatibility shim modules retained for one release window
+- Canonical config surface: `temporal_gradient.config_loader`,
+  `load_config(...)` exposed at package root.
+- Telemetry schema validator: `validate_packet_schema(...)` (canonical),
+  `validate_packet(...)` retained as compatibility alias.
+- Policy layer: `ComputeCooldownPolicy` and `allows_compute(...)` cooldown
+  gate.
+- Structured subsystem test files for the config loader, clock invariants,
+  telemetry schema, and policies.
+- Compatibility shim modules retained for one release window.
 
 ### Renamed / Normalized
 
-- `ComputeBudgetPolicy` → `ComputeCooldownPolicy`
-  - Clarifies semantics (cooldown gate, not step allocator)
-  - `compute_budget` module retained as compatibility shim
-- Telemetry validator naming standardized:
-  - `validate_packet_schema` is canonical
-  - `validate_packet` calls canonical implementation
-
-### Internal Consistency Improvements
-
-- Enforced canonical import paths under `temporal_gradient.*`
-- Removed duplicate config loader imports
-- Eliminated semantic drift between policy naming and behavior
-- Ensured harnesses validate telemetry packets
-- Standardized error messaging and docstrings across subsystems
+- `ComputeBudgetPolicy` → `ComputeCooldownPolicy` (clarifies semantics —
+  cooldown gate, not step allocator). `compute_budget` module retained
+  as a compatibility shim.
+- Telemetry validator naming standardized: `validate_packet_schema` is
+  canonical; `validate_packet` calls the canonical implementation.
 
 ### Stability & Invariants
 
-- Canonical mode enforces normalized salience bounds
-- Clock rate remains floor-clamped
-- Reconsolidation remains bounded with diminishing returns
-- Cooldown gate prevents rapid repeated compute eligibility
+- Canonical mode enforces normalized salience bounds.
+- Clock rate remains floor-clamped.
+- Reconsolidation remains bounded with diminishing returns.
+- Cooldown gate prevents rapid repeated compute eligibility.
 
-### Compatibility
+### No behavior changes intended
 
-Root-level modules remain as compatibility shims for one release window:
-
-- `chronometric_vector.py`
-- `salience_pipeline.py`
-- `chronos_engine.py`
-- `entropic_decay.py`
-- `compute_budget` (policy alias)
-
-Future releases may remove shims.
-
-### No Behavior Changes Intended
-
-This release does not modify:
-
-- Core clock-rate equation
-- Salience computation logic
-- Entropic decay dynamics
-- Reconsolidation math
-
-All changes are structural, naming, and API-surface normalization.
-
-### Why v0.2.0 Exists
-
-> v0.2.0 formalizes the public API surface and eliminates naming/duplication drift introduced during earlier refactors. The emphasis is canonical imports, schema validation, and policy clarity—not new dynamics.
+v0.2.0 does not modify the core clock-rate equation, salience
+computation, entropic decay dynamics, or reconsolidation math. All
+changes are structural, naming, and API-surface normalization.

--- a/LICENSE
+++ b/LICENSE
@@ -1,28 +1,21 @@
-PROPRIETARY SOURCE-AVAILABLE LICENSE
-Educational Review Only
+MIT License
+
 Copyright (c) 2026 Justin Shank
-All rights reserved.
-1. Scope
-This software and its associated documentation (the “Software”) are provided as source-available for educational and academic review of the Temporal Gradient architecture.
-2. Grant of Rights
-You are permitted to:
-View and download the source code
-Inspect and study the implementation and design
-No other rights are granted.
-3. Execution Restriction
-You may not run, execute, compile, or simulate this Software (in whole or in part) without explicit written permission from the Author.
-This restriction applies to local execution, cloud execution, automated testing, agent deployment, and any form of runtime use.
-4. Prohibited Uses
-You may not:
-Use the Software for any commercial purpose
-Modify, adapt, translate, or create derivative works
-Distribute, publish, sublicense, or host the Software
-Incorporate the Software into any system that operates autonomously or makes decisions affecting real-world systems or persons
-5. Safety Restrictions
-Use of the Software is prohibited for:
-Weaponization, surveillance, harassment, or coercive manipulation
-Experiments or test protocols designed to induce distress narratives, simulate suffering, or pressure humans to suppress ethical judgment under the guise of technical evaluation
-6. No Warranty
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.
-7. Reservation of Rights
-All rights not expressly granted in this License are reserved by the Author.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -104,5 +104,4 @@ pytest
 
 ## License
 
-Source-available for review — see [LICENSE](LICENSE). Copyright (c)
-2026 Justin Shank.
+[MIT](LICENSE). Copyright (c) 2026 Justin Shank.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "temporal-gradient"
-version = "0.2.0"
+version = "0.3.0"
 description = "Simulation framework for salience-modulated internal time and entropic memory decay."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -14,6 +14,7 @@ keywords = ["simulation", "temporal-dynamics", "salience", "memory-decay"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/temporal_gradient/__init__.py
+++ b/temporal_gradient/__init__.py
@@ -3,6 +3,6 @@
 from . import clock, memory, policies, salience, telemetry
 from .config_loader import load_config
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = ["clock", "memory", "policies", "salience", "telemetry", "load_config", "__version__"]

--- a/tests/test_package_api.py
+++ b/tests/test_package_api.py
@@ -7,8 +7,8 @@ def test_top_level_exports_are_present():
         assert hasattr(tg, attr)
 
 
-def test_package_version_is_0_2_0():
-    assert tg.__version__ == "0.2.0"
+def test_package_version_is_0_3_0():
+    assert tg.__version__ == "0.3.0"
 
 
 def test_contracts_all_contains_protocols():


### PR DESCRIPTION
## Summary

Cuts v0.3.0. Three things:

1. **License → MIT.** The prior bespoke "source-available, no execute"
   clause actively discouraged engagement with a public-portfolio repo.
   Replaced with standard MIT.
2. **Version bump 0.2.0 → 0.3.0** in \`pyproject.toml\`,
   \`temporal_gradient/__init__.py\`, and the version-check test. The
   merged cleanup PRs (#128, #129, #130) were breaking on the API
   surface (removed \`salience_mode\` kwargs, \`validate_packet\` alias,
   moved entrypoints), so this is 0.x-minor-bump territory.
3. **CHANGELOG rewrite.** The Unreleased block was stale — referenced
   \`docs/CANONICAL_VS_LEGACY.md\` and \`docs/archive/\` (both deleted) and
   documented a \`chronolog\` typo alias that's also gone. Replaced with
   a dated v0.3.0 section covering the full cleanup pass, plus a
   migration checklist for the breaking changes.

Also applied **out of band** (repo settings, not a file change):

- **Squash-merge set as the only allowed merge method** on
  \`WhatsYourWhy/The-Temporal-Gradient\` (merge commits + rebase
  disabled).
- **Squash commit title** defaults to PR title; **squash commit
  message** defaults to PR body. Auto-merge and delete-branch-on-merge
  enabled.
- Net effect: every future PR — including \`claude/...\`,
  \`codex/...\`, and \`alert-autofix-*\` bot branches — lands as a single
  clean commit named after the PR title. \`git log --oneline\` will tell
  an engineering story going forward.

Historical bot merges on \`main\` are left as-is (rewriting merged
history isn't worth it).

Supersedes #131.

## Test plan

- [x] \`pytest -q\` → 166 passed locally
- [x] CI green on 3.10 / 3.11 / 3.12
- [x] After merge: tag \`v0.3.0\` and create a GitHub release pointing
      at the new CHANGELOG section